### PR TITLE
removed draft reference from API definition

### DIFF
--- a/public/api/conf/application.yaml
+++ b/public/api/conf/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 1.0.0 draft
+  version: 1.0.0
   title: National Insurance Contribution and Credits Interface Specification to retrieve Class 1 and Class 2 data.
   description: |-
     # Usage Terms


### PR DESCRIPTION
Removed the word "draft" from the API definition in the application.yaml as this is the final agreed version of this document