### PR TITLE
hotfix/add-application.raml

### DIFF
--- a/public/api/conf/application.raml
+++ b/public/api/conf/application.raml
@@ -1,0 +1,174 @@
+#%RAML 1.0
+title: National Insurance Contribution and Credits Interface
+version: 1.0.0 draft
+description: |
+  # Usage Terms
+  These interfaces are business-critical interfaces for HMRC and DWP, supporting thousands of staff - all consumption, or change in consumption levels, should be registered and fully approved (see Registered Consumers below).
+baseUri: https://{environment}.service.hmrc.gov.uk
+protocols: [ HTTPS ]
+mediaType: application/json
+
+/:
+  uriParameters:
+    environment:
+      enum: [ test-api, api ]
+      description: The environment of the API (sandbox or production).
+
+/misc/national-insurance-contributions-and-credits/contribution-and-credits:
+  post:
+    description: |
+      # Purpose
+      This API provides the capability to retrieve Class 1 and Class 2 data for an account.<br>
+      - This allows a search for Class 1 contributions and Class 2 credits for a given NINO (suffix optional) and range of tax years.
+      - Request payload will contain the start tax year, end tax year, national insurance number and date of birth.<br>
+      - This endpoint requires Mutual Authentication over TLS 1.2.
+    securedBy: [ applicationRestricted ]
+    body:
+      application/json:
+        type: PostNIContCredRequest
+    responses:
+      200:
+        description: Successful Response
+        headers:
+          correlationId: correlationId
+        body:
+          application/json;charset=UTF-8:
+            type: PostNIContCredResponse
+      400:
+        description: Bad Request
+        headers:
+          correlationId: correlationId
+        body:
+          application/json;charset=UTF-8:
+            type: errorResponse_400
+      403:
+        description: Forbidden
+        headers:
+          correlationId: correlationId
+        body:
+          application/json;charset=UTF-8:
+            type: errorResponse_403
+      422:
+        description: Unprocessable Entity
+        headers:
+          correlationId: correlationId
+        body:
+          application/json;charset=UTF-8:
+            type: errorResponse_422
+      404:
+        description: Resource not found.
+      500:
+        description: Internal Server Error.
+
+securitySchemes:
+  applicationRestricted:
+    type: OAuth 2.0
+    description: |
+      HMRC supports OAuth 2.0 for authenticating application restricted API requests using an OAuth 2.0 Bearer Token in the AUTHORIZATION header.
+      See https://developer.service.hmrc.gov.uk/api-documentation/docs/authorisation/application-restricted-endpoints for details.
+    settings:
+      accessTokenUri: https://api.service.hmrc.gov.uk/oauth/token
+      scopes:
+        - write:protect-connect
+
+types:
+  correlationId:
+    type: string
+    description: Correlation ID - used for traceability purposes.
+    example: e470d658-99f7-4292-a4a1-ed12c72f1337
+
+  PostNIContCredRequest:
+    type: object
+    properties:
+      startTaxYear:
+        type: string
+        example: "2016"
+      endTaxYear:
+        type: string
+        example: "2021"
+      dateOfBirth:
+        type: string
+        example: "1980-01-01"
+      nationalInsuranceNumber:
+        type: string
+        example: "AB123456A"
+      customerCorrelationID:
+        type: string
+        example: "e470d658-99f7-4292-a4a1-ed12c72f1337"
+    required: [startTaxYear, endTaxYear, dateOfBirth, nationalInsuranceNumber]
+
+  PostNIContCredResponse:
+    type: object
+    properties:
+      niClass1:
+        type: niClass1[]
+      niClass2:
+        type: niClass2[]
+
+  niClass1:
+    type: object
+    properties:
+      taxYear:
+        type: integer
+      niContributionCategory:
+        type: string
+      niContributionCategoryName:
+        type: string
+      niContributionType:
+        type: string
+      totalPrimaryContribution:
+        type: number
+      contributionStatus:
+        type: string
+
+  niClass2:
+    type: object
+    properties:
+      taxYear:
+        type: integer
+      numberOfWeeks:
+        type: integer
+      niContributionType:
+        type: string
+      totalEarningsFactor:
+        type: number
+      totalPrimaryContribution:
+        type: number
+      contributionStatus:
+        type: string
+
+  errorResponse_400:
+    type: object
+    properties:
+      failures:
+        type: errorResourceObj_400[]
+
+  errorResourceObj_400:
+    type: object
+    properties:
+      reason:
+        type: string
+      code:
+        type: string
+
+  errorResponse_403:
+    type: object
+    properties:
+      reason:
+        type: string
+      code:
+        type: string
+
+  errorResponse_422:
+    type: object
+    properties:
+      failures:
+        type: errorResourceObj_422[]
+
+  errorResourceObj_422:
+    type: object
+    properties:
+      reason:
+        type: string
+      code:
+        type: string

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: National Insurance Contribution and Credits Interface
-version: 1.0.0 draft
+version: 1.0.0
 description: |
   # Usage Terms
   These interfaces are business-critical interfaces for HMRC and DWP, supporting thousands of staff - all consumption, or change in consumption levels, should be registered and fully approved (see Registered Consumers below).

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -1,0 +1,174 @@
+#%RAML 1.0
+title: National Insurance Contribution and Credits Interface
+version: 1.0.0 draft
+description: |
+  # Usage Terms
+  These interfaces are business-critical interfaces for HMRC and DWP, supporting thousands of staff - all consumption, or change in consumption levels, should be registered and fully approved (see Registered Consumers below).
+baseUri: https://{environment}.service.hmrc.gov.uk
+protocols: [ HTTPS ]
+mediaType: application/json
+
+/:
+  uriParameters:
+    environment:
+      enum: [ test-api, api ]
+      description: The environment of the API (sandbox or production).
+
+/misc/national-insurance-contributions-and-credits/contribution-and-credits:
+  post:
+    description: |
+      # Purpose
+      This API provides the capability to retrieve Class 1 and Class 2 data for an account.<br>
+      - This allows a search for Class 1 contributions and Class 2 credits for a given NINO (suffix optional) and range of tax years.
+      - Request payload will contain the start tax year, end tax year, national insurance number and date of birth.<br>
+      - This endpoint requires Mutual Authentication over TLS 1.2.
+    securedBy: [ applicationRestricted ]
+    body:
+      application/json:
+        type: PostNIContCredRequest
+    responses:
+      200:
+        description: Successful Response
+        headers:
+          correlationId: correlationId
+        body:
+          application/json;charset=UTF-8:
+            type: PostNIContCredResponse
+      400:
+        description: Bad Request
+        headers:
+          correlationId: correlationId
+        body:
+          application/json;charset=UTF-8:
+            type: errorResponse_400
+      403:
+        description: Forbidden
+        headers:
+          correlationId: correlationId
+        body:
+          application/json;charset=UTF-8:
+            type: errorResponse_403
+      422:
+        description: Unprocessable Entity
+        headers:
+          correlationId: correlationId
+        body:
+          application/json;charset=UTF-8:
+            type: errorResponse_422
+      404:
+        description: Resource not found.
+      500:
+        description: Internal Server Error.
+
+securitySchemes:
+  applicationRestricted:
+    type: OAuth 2.0
+    description: |
+      HMRC supports OAuth 2.0 for authenticating application restricted API requests using an OAuth 2.0 Bearer Token in the AUTHORIZATION header.
+      See https://developer.service.hmrc.gov.uk/api-documentation/docs/authorisation/application-restricted-endpoints for details.
+    settings:
+      accessTokenUri: https://api.service.hmrc.gov.uk/oauth/token
+      scopes:
+        - write:protect-connect
+
+types:
+  correlationId:
+    type: string
+    description: Correlation ID - used for traceability purposes.
+    example: e470d658-99f7-4292-a4a1-ed12c72f1337
+
+  PostNIContCredRequest:
+    type: object
+    properties:
+      startTaxYear:
+        type: string
+        example: "2016"
+      endTaxYear:
+        type: string
+        example: "2021"
+      dateOfBirth:
+        type: string
+        example: "1980-01-01"
+      nationalInsuranceNumber:
+        type: string
+        example: "AB123456A"
+      customerCorrelationID:
+        type: string
+        example: "e470d658-99f7-4292-a4a1-ed12c72f1337"
+    required: [startTaxYear, endTaxYear, dateOfBirth, nationalInsuranceNumber]
+
+  PostNIContCredResponse:
+    type: object
+    properties:
+      niClass1:
+        type: niClass1[]
+      niClass2:
+        type: niClass2[]
+
+  niClass1:
+    type: object
+    properties:
+      taxYear:
+        type: integer
+      niContributionCategory:
+        type: string
+      niContributionCategoryName:
+        type: string
+      niContributionType:
+        type: string
+      totalPrimaryContribution:
+        type: number
+      contributionStatus:
+        type: string
+
+  niClass2:
+    type: object
+    properties:
+      taxYear:
+        type: integer
+      numberOfWeeks:
+        type: integer
+      niContributionType:
+        type: string
+      totalEarningsFactor:
+        type: number
+      totalPrimaryContribution:
+        type: number
+      contributionStatus:
+        type: string
+
+  errorResponse_400:
+    type: object
+    properties:
+      failures:
+        type: errorResourceObj_400[]
+
+  errorResourceObj_400:
+    type: object
+    properties:
+      reason:
+        type: string
+      code:
+        type: string
+
+  errorResponse_403:
+    type: object
+    properties:
+      reason:
+        type: string
+      code:
+        type: string
+
+  errorResponse_422:
+    type: object
+    properties:
+      failures:
+        type: errorResourceObj_422[]
+
+  errorResourceObj_422:
+    type: object
+    properties:
+      reason:
+        type: string
+      code:
+        type: string


### PR DESCRIPTION
Add the application.raml file for the sake of the initial deployment to check that it exists and is the same as the OAS spec. This can be deleted once deployed the initial time as per [this guide on RAML use in services](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=DTRG&title=RAML+to+OpenAPI+Specification+%28OAS%29+migration+guide#RAMLtoOpenAPISpecification(OAS)migrationguide-ConvertRAMLintoOASwithAPImatic) since it's use is [deprecated](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=DTRG&title=RAML+producers+guide+-+DEPRECATED).