### PR TITLE
DWPDAT-20: integrate marriage details endpoint

### DIFF
--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/EligibilityCheckDataResult.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/EligibilityCheckDataResult.scala
@@ -16,15 +16,20 @@
 
 package uk.gov.hmrc.app.benefitEligibility.integration.outbound
 
-import uk.gov.hmrc.app.benefitEligibility.common.{OverallResultStatus, OverallResultSummary}
-import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResponseStatus.{Failure, Success}
+import uk.gov.hmrc.app.benefitEligibility.common.{CorrelationId, OverallResultStatus, OverallResultSummary}
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResult.{
   Class2MaReceiptsResult,
   ContributionCreditResult,
-  LiabilityResult
+  LiabilityResult,
+  MarriageDetailsResult
 }
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResponseStatus.{Failure, Success}
 import uk.gov.hmrc.app.benefitEligibility.service.aggregation.ResultAggregation.ResultAggregator
-import uk.gov.hmrc.app.benefitEligibility.service.aggregation.aggregators.AggregationServiceMA
+import uk.gov.hmrc.app.benefitEligibility.service.aggregation.aggregators.{
+  AggregationServiceBSP,
+  AggregationServiceGYSP,
+  AggregationServiceMA
+}
 
 sealed trait EligibilityCheckDataResult {
   def allResults: List[NpsApiResult]
@@ -48,8 +53,8 @@ object EligibilityCheckDataResult {
     case result: EligibilityCheckDataResultMA   => AggregationServiceMA.aggregator.aggregate(result)
     case result: EligibilityCheckDataResultESA  => ???
     case result: EligibilityCheckDataResultJSA  => ???
-    case result: EligibilityCheckDataResultGYSP => ???
-    case result: EligibilityCheckDataResultBSP  => ???
+    case result: EligibilityCheckDataResultGYSP => AggregationServiceGYSP.aggregator.aggregate(result)
+    case result: EligibilityCheckDataResultBSP  => AggregationServiceBSP.aggregator.aggregate(result)
   }
 
   case class EligibilityCheckDataResultMA(
@@ -70,12 +75,16 @@ object EligibilityCheckDataResult {
     override def allResults: List[NpsApiResult] = ???
   }
 
-  case class EligibilityCheckDataResultGYSP() extends EligibilityCheckDataResult {
-    override def allResults: List[NpsApiResult] = ???
+  case class EligibilityCheckDataResultGYSP(
+      marriageDetailsResult: MarriageDetailsResult
+  ) extends EligibilityCheckDataResult {
+    override def allResults: List[NpsApiResult] = List(marriageDetailsResult)
   }
 
-  case class EligibilityCheckDataResultBSP() extends EligibilityCheckDataResult {
-    override def allResults: List[NpsApiResult] = ???
+  case class EligibilityCheckDataResultBSP(
+      marriageDetailsResult: MarriageDetailsResult
+  ) extends EligibilityCheckDataResult {
+    override def allResults: List[NpsApiResult] = List(marriageDetailsResult)
   }
 
 }

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/NpsApiResponse.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/NpsApiResponse.scala
@@ -16,4 +16,4 @@
 
 package uk.gov.hmrc.app.benefitEligibility.integration.outbound
 
-trait NpsApiResponse
+trait NpsApiResponse {}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/NpsApiResult.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/NpsApiResult.scala
@@ -18,9 +18,15 @@ package uk.gov.hmrc.app.benefitEligibility.integration.outbound
 
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.app.benefitEligibility.common.ApiName.{Class2MAReceipts, ContributionCredit, Liabilities}
 import uk.gov.hmrc.app.benefitEligibility.common.{ApiName, TextualErrorStatusCode}
+import uk.gov.hmrc.app.benefitEligibility.common.ApiName.{
+  Class2MAReceipts,
+  ContributionCredit,
+  Liabilities,
+  MarriageDetails
+}
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.class2MAReceipts.model.response.Class2MAReceiptsSuccess.Class2MAReceiptsSuccessResponse
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsSuccess.MarriageDetailsSuccessResponse
 
 import scala.collection.immutable
 
@@ -28,7 +34,9 @@ sealed abstract class NpsApiResponseStatus(override val entryName: String) exten
 
 object NpsApiResponseStatus extends Enum[NpsApiResponseStatus] with PlayJsonEnum[NpsApiResponseStatus] {
   val values: immutable.IndexedSeq[NpsApiResponseStatus] = findValues
+
   case object Success extends NpsApiResponseStatus("SUCCESS")
+
   case object Failure extends NpsApiResponseStatus("FAILURE")
 }
 
@@ -52,6 +60,14 @@ sealed trait NpsApiResult extends ApiResult {
 }
 
 object NpsApiResult {
+
+  case class MarriageDetailsResult(
+      status: NpsApiResponseStatus,
+      successResponse: Option[MarriageDetailsSuccessResponse],
+      error: Option[NpsError]
+  ) extends NpsApiResult {
+    val apiName: ApiName = MarriageDetails
+  }
 
   case class Class2MaReceiptsResult(
       status: NpsApiResponseStatus,

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/NpsSuccessfulApiResponse.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/NpsSuccessfulApiResponse.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.app.benefitEligibility.integration.outbound
 
 import play.api.libs.json.Writes
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.class2MAReceipts.model.response.Class2MAReceiptsSuccess
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsSuccess.MarriageDetailsSuccessResponse
 
 trait NpsSuccessfulApiResponse extends NpsApiResponse
 
@@ -26,6 +27,8 @@ object NpsSuccessfulApiResponse {
   implicit val npsSuccessfulApiResponseWrites: Writes[NpsSuccessfulApiResponse] = Writes {
     case r: Class2MAReceiptsSuccess.Class2MAReceiptsSuccessResponse =>
       Class2MAReceiptsSuccess.Class2MAReceiptsSuccessResponse.getClass2MAReceiptsResponseWrites.writes(r)
+    case m: MarriageDetailsSuccessResponse =>
+      MarriageDetailsSuccessResponse.getMarriageDetailsResponseWrites.writes(m)
   }
 
 }

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/connector/MarriageDetailsConnector.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/connector/MarriageDetailsConnector.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.connector
+
+import cats.data.EitherT
+import play.api.http.Status.*
+import uk.gov.hmrc.app.benefitEligibility.common.TextualErrorStatusCode.{InternalServerError, NotFound}
+import uk.gov.hmrc.app.benefitEligibility.common.{BenefitEligibilityError, CorrelationId}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResult.MarriageDetailsResult
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsClient
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.mapper.MarriageDetailsResponseMapper
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsError.{
+  MarriageDetailsErrorResponse400,
+  MarriageDetailsErrorResponse403,
+  MarriageDetailsErrorResponse422
+}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsSuccess.MarriageDetailsSuccessResponse
+import uk.gov.hmrc.app.benefitEligibility.util.HttpParsing.attemptParse
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class MarriageDetailsConnector @Inject() (
+    npsClient: NpsClient,
+    marriageDetailsResponseMapper: MarriageDetailsResponseMapper
+)(implicit ec: ExecutionContext) {
+
+  def fetchMarriageDetails(
+      path: String
+  )(implicit hc: HeaderCarrier): EitherT[Future, BenefitEligibilityError, MarriageDetailsResult] =
+    npsClient
+      .get(path)
+      .flatMap { response =>
+        val marriageDetailsResponse =
+          response.status match {
+            case OK =>
+              attemptParse[MarriageDetailsSuccessResponse](response).map(marriageDetailsResponseMapper.toResult)
+            case BAD_REQUEST =>
+              attemptParse[MarriageDetailsErrorResponse400](response).map(marriageDetailsResponseMapper.toResult)
+            case FORBIDDEN =>
+              attemptParse[MarriageDetailsErrorResponse403](response).map(marriageDetailsResponseMapper.toResult)
+            case UNPROCESSABLE_ENTITY =>
+              attemptParse[MarriageDetailsErrorResponse422](response).map(marriageDetailsResponseMapper.toResult)
+            case NOT_FOUND => Right(marriageDetailsResponseMapper.toResult(NotFound))
+            case _         => Right(marriageDetailsResponseMapper.toResult(InternalServerError))
+          }
+
+        EitherT.fromEither[Future](marriageDetailsResponse)
+      }
+
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/mapper/MarriageDetailsResponseMapper.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/mapper/MarriageDetailsResponseMapper.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.mapper
+
+import uk.gov.hmrc.app.benefitEligibility.common.TextualErrorStatusCode
+import uk.gov.hmrc.app.benefitEligibility.common.TextualErrorStatusCode.{
+  AccessForbidden,
+  BadRequest,
+  UnprocessableEntity
+}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResponseStatus.{Failure, Success}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResult.MarriageDetailsResult
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsSuccess.MarriageDetailsSuccessResponse
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.{
+  MarriageDetailsError,
+  MarriageDetailsResponse
+}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.{NpsError, NpsResponseMapper}
+
+class MarriageDetailsResponseMapper extends NpsResponseMapper[MarriageDetailsResponse, MarriageDetailsResult] {
+
+  def toResult(response: MarriageDetailsResponse): MarriageDetailsResult =
+    response match {
+
+      case response: MarriageDetailsSuccessResponse =>
+        MarriageDetailsResult(Success, Some(response), None)
+
+      case MarriageDetailsError.MarriageDetailsErrorResponse400(failures) =>
+        MarriageDetailsResult(
+          Failure,
+          None,
+          Some(NpsError(code = BadRequest, message = failures.map(_.reason).mkString(","), downstreamStatus = 400))
+        )
+
+      case MarriageDetailsError.MarriageDetailsErrorResponse403(reason, code) =>
+        MarriageDetailsResult(
+          Failure,
+          None,
+          Some(NpsError(code = AccessForbidden, message = reason.entryName, downstreamStatus = 403))
+        )
+
+      case MarriageDetailsError.MarriageDetailsErrorResponse422(failures) =>
+        MarriageDetailsResult(
+          Failure,
+          None,
+          Some(
+            NpsError(
+              code = UnprocessableEntity,
+              message = failures.map(_.reason).mkString(","),
+              downstreamStatus = 422
+            )
+          )
+        )
+    }
+
+  def toResult(textualErrorStatusCode: TextualErrorStatusCode) =
+    MarriageDetailsResult(
+      Failure,
+      None,
+      Some(
+        NpsError(
+          textualErrorStatusCode,
+          textualErrorStatusCode.message,
+          textualErrorStatusCode.code
+        )
+      )
+    )
+
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/request/MarriageDetailsRequestHelper.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/request/MarriageDetailsRequestHelper.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.request
+
+import cats.implicits.catsSyntaxSemigroup
+import uk.gov.hmrc.app.benefitEligibility.integration.inbound.{
+  BSPEligibilityCheckDataRequest,
+  GYSPEligibilityCheckDataRequest
+}
+
+class MarriageDetailsRequestHelper {
+
+  def buildRequestPath(host: String, req: GYSPEligibilityCheckDataRequest): String = {
+    def searchStartYear: Option[String] = req.searchStartYear.map(sY => s"searchStartYear=$sY&")
+
+    def searchEndYear: Option[String] = req.searchEndYear.map(eY => s"searchEndYear=$eY&")
+
+    def latest: Option[String] = req.latest.map(l => s"latest=$l&")
+
+    def sequence: Option[String] = req.sequence.map(s => s"sequence=$s")
+
+    val options = searchStartYear.combine(searchEndYear).combine(latest).combine(sequence.map(result => s"?$result"))
+    s"$host/ni/individual/${req.identifier}/marriage-cp$options/"
+  }
+
+  def buildRequestPath(host: String, req: BSPEligibilityCheckDataRequest): String = {
+    def searchStartYear: Option[String] = req.searchStartYear.map(sY => s"searchStartYear=$sY&")
+
+    def searchEndYear: Option[String] = req.searchEndYear.map(eY => s"searchEndYear=$eY&")
+
+    def latest: Option[String] = req.latest.map(l => s"latest=$l&")
+
+    def sequence: Option[String] = req.sequence.map(s => s"sequence=$s")
+
+    val options = searchStartYear.combine(searchEndYear).combine(latest).combine(sequence.map(result => s"?$result"))
+    s"$host/ni/individual/${req.identifier}/marriage-cp$options/"
+  }
+
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/response/MarriageDetailsResponse.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/response/MarriageDetailsResponse.scala
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response
+
+import cats.data.{Validated, ValidatedNel}
+import cats.implicits.catsSyntaxTuple2Semigroupal
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
+import play.api.libs.json.*
+import uk.gov.hmrc.app.benefitEligibility.common.Identifier
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.{NpsApiResponse, NpsSuccessfulApiResponse}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.enums.{
+  MarriageEndDateStatus,
+  MarriageStartDateStatus,
+  MarriageStatus
+}
+import uk.gov.hmrc.app.benefitEligibility.util.SuccessfulResult
+
+import java.time.LocalDate
+import scala.collection.immutable
+
+sealed trait MarriageDetailsResponse extends NpsApiResponse
+
+object MarriageDetailsError {
+
+  // region Common
+
+  final case class Reason private (value: String)
+
+  object Reason {
+    private val minLength = 1
+    private val maxLength = 120
+
+    private def from(value: String): ValidatedNel[String, Reason] =
+      (
+        Validated.condNel(
+          value.length >= minLength,
+          SuccessfulResult,
+          "provided value is below the minimum length limit"
+        ),
+        Validated.condNel(value.length <= maxLength, SuccessfulResult, "provided value exceeds the max length limit")
+      ).mapN((_, _) => Reason(value))
+
+    implicit val reads: Reads[Reason] = {
+      case JsString(value) =>
+        Reason
+          .from(value)
+          .leftMap(errors => JsError(__ -> JsonValidationError(errors.toList.mkString(","))))
+          .fold(identity, JsSuccess(_))
+      case _ => JsError(__ -> JsonValidationError("wrong data type, expected String"))
+    }
+
+  }
+
+  // endregion Common
+
+  // region Error400
+
+  sealed abstract class ErrorCode400(override val entryName: String) extends EnumEntry
+
+  object ErrorCode400 extends Enum[ErrorCode400] with PlayJsonEnum[ErrorCode400] {
+    val values: immutable.IndexedSeq[ErrorCode400] = findValues
+
+    case object Constraint_Violation extends ErrorCode400("400.1")
+
+    case object Message_Not_Readable extends ErrorCode400("400.2")
+  }
+
+  case class MarriageDetailsError400(reason: Reason, code: ErrorCode400)
+
+  object MarriageDetailsError400 {
+    implicit val npsErrorResponse400Reads: Reads[MarriageDetailsError400] = Json.reads[MarriageDetailsError400]
+  }
+
+  case class MarriageDetailsErrorResponse400(failures: List[MarriageDetailsError400]) extends MarriageDetailsResponse
+
+  object MarriageDetailsErrorResponse400 {
+
+    implicit val npsFailureResponse400Reads: Reads[MarriageDetailsErrorResponse400] =
+      Json.reads[MarriageDetailsErrorResponse400]
+
+  }
+
+  // endregion Error400
+
+  // region Error403
+
+  sealed abstract class ErrorCode403(override val entryName: String) extends EnumEntry
+
+  object ErrorCode403 extends Enum[ErrorCode403] with PlayJsonEnum[ErrorCode403] {
+    val values: immutable.IndexedSeq[ErrorCode403] = findValues
+
+    case object ErrorCode403_2 extends ErrorCode403("403.2")
+  }
+
+  sealed abstract class ErrorReason403(override val entryName: String) extends EnumEntry
+
+  object ErrorReason403 extends Enum[ErrorReason403] with PlayJsonEnum[ErrorReason403] {
+    val values: immutable.IndexedSeq[ErrorReason403] = findValues
+
+    case object Forbidden extends ErrorReason403("Forbidden")
+  }
+
+  case class MarriageDetailsErrorResponse403(reason: ErrorReason403, code: ErrorCode403) extends MarriageDetailsResponse
+
+  object MarriageDetailsErrorResponse403 {
+
+    implicit val npsFailureResponse403Reads: Reads[MarriageDetailsErrorResponse403] =
+      Json.reads[MarriageDetailsErrorResponse403]
+
+  }
+
+  // endregion Error403
+
+  // region Error422
+
+  final case class ErrorCode422 private (value: String)
+
+  object ErrorCode422 {
+
+    implicit val reads: Reads[ErrorCode422] = Json.reads[ErrorCode422]
+
+  }
+
+  case class MarriageDetailsError422(reason: Reason, code: ErrorCode422)
+
+  object MarriageDetailsError422 {
+    implicit val NpsErrorResponse422Reads: Reads[MarriageDetailsError422] = Json.reads[MarriageDetailsError422]
+  }
+
+  case class MarriageDetailsErrorResponse422(failures: List[MarriageDetailsError422]) extends MarriageDetailsResponse
+
+  object MarriageDetailsErrorResponse422 {
+
+    implicit val npsFailureResponse422Reads: Reads[MarriageDetailsErrorResponse422] =
+      Json.reads[MarriageDetailsErrorResponse422]
+
+  }
+
+  // endregion Error422
+
+}
+
+object MarriageDetailsSuccess {
+
+  // region Active Marriage
+
+  case class ActiveMarriage(value: Boolean) extends AnyVal
+
+  object ActiveMarriage {
+    implicit val activeMarriageReads: Format[ActiveMarriage] = Json.valueFormat[ActiveMarriage]
+  }
+
+  // endregion Active Marriage
+
+  // region Marriage Details List
+
+  final case class SequenceNumber private (value: Int)
+
+  object SequenceNumber {
+
+    private val minValue = 1
+    private val maxValue = 126
+
+    private def from(value: Int): ValidatedNel[String, SequenceNumber] =
+      (
+        Validated.condNel(value >= minValue, SuccessfulResult, "provided value is below the minimum value"),
+        Validated.condNel(value <= maxValue, SuccessfulResult, "provided value exceeds the max value")
+      ).mapN((_, _) => SequenceNumber(value))
+
+    implicit val sequenceNumberReads: Reads[SequenceNumber] = {
+      case JsNumber(value) =>
+        SequenceNumber
+          .from(value.toInt)
+          .leftMap(errors => JsError(__ -> JsonValidationError(errors.toList.mkString(","))))
+          .fold(identity, JsSuccess(_))
+
+      case _ => JsError(__ -> JsonValidationError("wrong data type, expected Integer"))
+    }
+
+    implicit val sequenceNumberWrites: Writes[SequenceNumber] = Json.writes[SequenceNumber]
+
+  }
+
+  case class StartDate(value: LocalDate) extends AnyVal
+
+  object StartDate {
+    implicit val startDateReads: Format[StartDate] = Json.valueFormat[StartDate]
+  }
+
+  case class EndDate(value: LocalDate) extends AnyVal
+
+  object EndDate {
+    implicit val endDateReads: Format[EndDate] = Json.valueFormat[EndDate]
+  }
+
+  final case class SpouseForename private (value: String)
+
+  object SpouseForename {
+    private val pattern = "^([A-Za-z '-]{1,99})+$".r
+
+    private def from(value: String): ValidatedNel[String, SpouseForename] =
+      Validated.condNel(pattern.matches(value), SpouseForename(value), "invalid spouse forename")
+
+    implicit val spouseForenameReads: Reads[SpouseForename] = {
+      case JsString(value) =>
+        SpouseForename
+          .from(value)
+          .leftMap(errors => JsError(__ -> JsonValidationError(errors.toList.mkString(","))))
+          .fold(identity, JsSuccess(_))
+      case _ => JsError(__ -> JsonValidationError("wrong data type, expected String"))
+    }
+
+    implicit val spouseForenameWrites: Writes[SpouseForename] = Json.writes[SpouseForename]
+
+  }
+
+  final case class SpouseSurname private (value: String)
+
+  object SpouseSurname {
+    private val pattern = "^([A-Za-z '-]{2,99})+$".r
+
+    private def from(value: String): ValidatedNel[String, SpouseSurname] =
+      Validated.condNel(pattern.matches(value), SpouseSurname(value), "invalid spouse surname")
+
+    implicit val spouseSurnameReads: Reads[SpouseSurname] = {
+      case JsString(value) =>
+        SpouseSurname
+          .from(value)
+          .leftMap(errors => JsError(__ -> JsonValidationError(errors.toList.mkString(","))))
+          .fold(identity, JsSuccess(_))
+      case _ => JsError(__ -> JsonValidationError("wrong data type, expected String"))
+    }
+
+    implicit val spouseSurnameWrites: Writes[SpouseSurname] = Json.writes[SpouseSurname]
+
+  }
+
+  case class SeparationDate(value: LocalDate) extends AnyVal
+
+  object SeparationDate {
+    implicit val separationDateReads: Format[SeparationDate] = Json.valueFormat[SeparationDate]
+  }
+
+  case class ReconciliationDate(value: LocalDate) extends AnyVal
+
+  object ReconciliationDate {
+    implicit val reconciliationDateReads: Format[ReconciliationDate] = Json.valueFormat[ReconciliationDate]
+  }
+
+  case class MarriageDetailsList(
+      sequenceNumber: Option[SequenceNumber],
+      status: Option[MarriageStatus],
+      startDate: Option[StartDate],
+      startDateStatus: Option[MarriageStartDateStatus],
+      endDate: Option[EndDate],
+      endDateStatus: Option[MarriageEndDateStatus],
+      spouseIdentifier: Option[Identifier],
+      spouseForename: Option[SpouseForename],
+      spouseSurname: Option[SpouseSurname],
+      separationDate: Option[SeparationDate],
+      reconciliationDate: Option[ReconciliationDate]
+  )
+
+  object MarriageDetailsList {
+    implicit val marriageDetailsListFormats: Format[MarriageDetailsList] = Json.format[MarriageDetailsList]
+  }
+
+  // endregion MarriageDetailsList
+
+  // region Links
+
+  case class Href(value: String) extends AnyVal
+
+  object Href {
+    implicit val hrefReads: Format[Href] = Json.valueFormat[Href]
+  }
+
+  sealed abstract class Methods(override val entryName: String) extends EnumEntry
+
+  object Methods extends Enum[Methods] with PlayJsonEnum[Methods] {
+    val values: immutable.IndexedSeq[Methods] = findValues
+
+    case object get extends Methods("get")
+  }
+
+  case class Self(
+      href: Option[Href],
+      methods: Option[Methods]
+  )
+
+  object Self {
+    implicit val selfReads: Reads[Self]   = Json.reads[Self]
+    implicit val selfWrites: Writes[Self] = Json.writes[Self]
+  }
+
+  case class Links(self: Self)
+
+  object Links {
+    implicit val linksReads: Reads[Links]   = Json.reads[Links]
+    implicit val linksWrites: Writes[Links] = Json.writes[Links]
+  }
+
+  // endregion Links
+
+  // region Marriage Details Success Response
+
+  case class MarriageDetailsSuccessResponse(
+      activeMarriage: Option[Boolean],
+      marriageDetailsList: Option[MarriageDetailsList],
+      marriageDetailsLinks: Option[Links]
+  ) extends MarriageDetailsResponse
+      with NpsSuccessfulApiResponse
+
+  object MarriageDetailsSuccessResponse {
+
+    implicit val getMarriageDetailsResponseReads: Reads[MarriageDetailsSuccessResponse] =
+      Json.reads[MarriageDetailsSuccessResponse]
+
+    implicit val getMarriageDetailsResponseWrites: Writes[MarriageDetailsSuccessResponse] =
+      Json.writes[MarriageDetailsSuccessResponse]
+
+  }
+
+  // endregion Marriage Details Success Response
+
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/response/enums/MarriageEndDateStatus.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/response/enums/MarriageEndDateStatus.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.app.benefitEligibility.common
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.enums
 
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 
 import scala.collection.immutable
 
-sealed abstract class ApiName(override val entryName: String) extends EnumEntry
+sealed abstract class MarriageEndDateStatus(override val entryName: String) extends EnumEntry
 
-object ApiName extends Enum[ApiName] with PlayJsonEnum[ApiName] {
-  val values: immutable.IndexedSeq[ApiName] = findValues
+object MarriageEndDateStatus extends Enum[MarriageEndDateStatus] with PlayJsonEnum[MarriageEndDateStatus] {
+  val values: immutable.IndexedSeq[MarriageEndDateStatus] = findValues
 
-  case object Class2MAReceipts   extends ApiName("Class2 MA Receipts")
-  case object Liabilities        extends ApiName("Liabilities")
-  case object ContributionCredit extends ApiName("Contribution Credit")
-  case object MarriageDetails    extends ApiName("Marriage Details")
+  case object InEffect   extends MarriageEndDateStatus("IN EFFECT")
+  case object NotKnown   extends MarriageEndDateStatus("NOT KNOWN")
+  case object Unverified extends MarriageEndDateStatus("UNVERIFIED")
+  case object Verified   extends MarriageEndDateStatus("VERIFIED")
 }

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/response/enums/MarriageStartDateStatus.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/response/enums/MarriageStartDateStatus.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.app.benefitEligibility.common
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.enums
 
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 
 import scala.collection.immutable
 
-sealed abstract class ApiName(override val entryName: String) extends EnumEntry
+sealed abstract class MarriageStartDateStatus(override val entryName: String) extends EnumEntry
 
-object ApiName extends Enum[ApiName] with PlayJsonEnum[ApiName] {
-  val values: immutable.IndexedSeq[ApiName] = findValues
+object MarriageStartDateStatus extends Enum[MarriageStartDateStatus] with PlayJsonEnum[MarriageStartDateStatus] {
+  val values: immutable.IndexedSeq[MarriageStartDateStatus] = findValues
 
-  case object Class2MAReceipts   extends ApiName("Class2 MA Receipts")
-  case object Liabilities        extends ApiName("Liabilities")
-  case object ContributionCredit extends ApiName("Contribution Credit")
-  case object MarriageDetails    extends ApiName("Marriage Details")
+  case object CoegConfirmed extends MarriageStartDateStatus("COEG CONFIRMED")
+  case object NotKnown      extends MarriageStartDateStatus("NOT KNOWN")
+  case object NotVerified   extends MarriageStartDateStatus("NOT VERIFIED")
+  case object Verified      extends MarriageStartDateStatus("VERIFIED")
 }

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/response/enums/MarriageStatus.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/response/enums/MarriageStatus.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.enums
+
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
+
+import scala.collection.immutable
+
+sealed abstract class MarriageStatus(override val entryName: String) extends EnumEntry
+
+object MarriageStatus extends Enum[MarriageStatus] with PlayJsonEnum[MarriageStatus] {
+  val values: immutable.IndexedSeq[MarriageStatus] = findValues
+
+  case object CivilPartner               extends MarriageStatus("CIVIL PARTNER")
+  case object CivilPartnershipAnnulled   extends MarriageStatus("CIVIL PARTNERSHIP ANNULLED")
+  case object CivilPartnershipDissolved  extends MarriageStatus("CIVIL PARTNERSHIP DISSOLVED")
+  case object CivilPartnershipTerminated extends MarriageStatus("CIVIL PARTNERSHIP TERMINATED - REASON N/K")
+  case object Divorced                   extends MarriageStatus("DIVORCED")
+  case object MarriageAnnulled           extends MarriageStatus("MARRIAGE ANNULLED")
+  case object MarriageTerminated         extends MarriageStatus("MARRIAGE TERMINATED - REASON NOT KNOWN")
+  case object Married                    extends MarriageStatus("MARRIED")
+  case object Single                     extends MarriageStatus("SINGLE")
+  case object SurvivingCivilPartner      extends MarriageStatus("SURVIVING CIVIL PARTNER")
+  case object Void                       extends MarriageStatus("VOID")
+  case object Widowed                    extends MarriageStatus("WIDOWED")
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/service/BspDataRetrievalService.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/service/BspDataRetrievalService.scala
@@ -17,22 +17,38 @@
 package uk.gov.hmrc.app.benefitEligibility.service
 
 import cats.data.EitherT
-import uk.gov.hmrc.app.benefitEligibility.common.BenefitEligibilityError
-import uk.gov.hmrc.app.benefitEligibility.integration.inbound.BSPEligibilityCheckDataRequest
+import com.google.inject.Inject
+import uk.gov.hmrc.app.benefitEligibility.common.{BenefitEligibilityError, CorrelationId}
+import uk.gov.hmrc.app.benefitEligibility.integration.inbound.{
+  BSPEligibilityCheckDataRequest,
+  EligibilityCheckDataRequest
+}
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.EligibilityCheckDataResult
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.EligibilityCheckDataResult.EligibilityCheckDataResultBSP
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.connector.MarriageDetailsConnector
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.request.MarriageDetailsRequestHelper
+import uk.gov.hmrc.app.config.AppConfig
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class BspDataRetrievalService(
-    implicit ec: ExecutionContext
-) {
+class BspDataRetrievalService @Inject() (
+    marriageDetailsConnector: MarriageDetailsConnector,
+    marriageDetailsRequestHelper: MarriageDetailsRequestHelper,
+    appConfig: AppConfig
+)(implicit ec: ExecutionContext) {
 
   def fetchEligibilityData(
       eligibilityCheckDataRequest: BSPEligibilityCheckDataRequest
-  ): EitherT[Future, BenefitEligibilityError, EligibilityCheckDataResultBSP] =
-    EitherT.pure[Future, BenefitEligibilityError](
-      EligibilityCheckDataResultBSP()
+  )(implicit hc: HeaderCarrier): EitherT[Future, BenefitEligibilityError, EligibilityCheckDataResultBSP] = {
+    val correlationId = CorrelationId.generate
+    for {
+      marriageDetailsResult <- marriageDetailsConnector.fetchMarriageDetails(
+        marriageDetailsRequestHelper.buildRequestPath(appConfig.hipBaseUrl, eligibilityCheckDataRequest)
+      )
+    } yield EligibilityCheckDataResultBSP(
+      marriageDetailsResult
     )
+  }
 
 }

--- a/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/AggregatedData.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/AggregatedData.scala
@@ -16,7 +16,19 @@
 
 package uk.gov.hmrc.app.benefitEligibility.service.aggregation
 
-import uk.gov.hmrc.app.benefitEligibility.common.{BenefitType, ReceiptDate}
+import uk.gov.hmrc.app.benefitEligibility.common.BenefitType.{BSP, GYSP, MA}
+import uk.gov.hmrc.app.benefitEligibility.common.{BenefitType, Identifier, ReceiptDate}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsSuccess.{
+  EndDate,
+  SpouseForename,
+  SpouseSurname,
+  StartDate
+}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.enums.{
+  MarriageEndDateStatus,
+  MarriageStartDateStatus,
+  MarriageStatus
+}
 
 sealed trait AggregatedData {
   def benefitType: BenefitType
@@ -33,7 +45,60 @@ object AggregatedData {
       //      startDate: LocalDate,
       //      endDate: LocalDate
   ) extends AggregatedData {
-    def benefitType: BenefitType = BenefitType.MA
+    def benefitType: BenefitType = MA
+  }
+
+  case class AggregatedDataBSP(
+      // primaryPaidEarnings: BigDecimal,
+      // contributionCategory: ContributionCategory,
+      // contributionCategoryLetter: ContributionCategoryLetter,
+      // primaryContribution: Int,
+      // class1ContributionStatus: Class1ContributionStatus,
+      // contributionCreditType: ContributionCreditType,
+      // taxYear: TaxYear,
+      // numberOfCreditsAndConts: Int,
+      status: MarriageStatus,
+      startDate: StartDate,
+      startDateStatus: MarriageStartDateStatus,
+      endDate: EndDate,
+      endDateStatus: MarriageEndDateStatus,
+      // terminationReason: String,
+      spouseIdentifier: Identifier,
+      spouseForename: SpouseForename,
+      spouseSurname: SpouseSurname
+  ) extends AggregatedData {
+    def benefitType: BenefitType = BSP
+  }
+
+  case class AggregatedDataGYSP(
+      // guaranteedMinimumPensionContractedOutDeductionsPre1988: Int,
+      // guaranteedMinimumPensionContractedOutDeductionsPost1988: Int,
+      // contractedOutDeductionsPre1988: Int,
+      // contractedOutDeductionsPost1988: Int,
+      // contributionCategory: ContributionCategory,
+      // contributionCategoryLetter: ContributionCategoryLetter,
+      // contributionCreditType: ContributionCreditType,
+      // taxYear: TaxYear,
+      // numberOfCreditsAndConts: Int,
+      // totalGraduatedPensionUnits: Int,
+      // employerName: String,
+      // longTermBenefitNotes: String,
+      status: MarriageStatus,
+      startDate: StartDate,
+      startDateStatus: MarriageStartDateStatus,
+      endDate: EndDate,
+      endDateStatus: MarriageEndDateStatus,
+      // terminationReason: String,
+      spouseIdentifier: Identifier,
+      spouseForename: SpouseForename,
+      spouseSurname: SpouseSurname
+      // schemeMembershipStartDate: StartDate,
+      // schemeMembershipEndDate: EndDate,
+      // employersContractedOutNumberDetails: Int,
+      // qualifyingTaxYear: TaxYear,
+      // primaryPainEarnings: BigDecimal
+  ) extends AggregatedData {
+    def benefitType: BenefitType = GYSP
   }
 
 }

--- a/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/aggregators/AggregationServiceBSP.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/aggregators/AggregationServiceBSP.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.service.aggregation.aggregators
+
+import uk.gov.hmrc.app.benefitEligibility.common.BenefitEligibilityDataFetchError
+import uk.gov.hmrc.app.benefitEligibility.common.BenefitType.BSP
+import uk.gov.hmrc.app.benefitEligibility.common.OverallResultStatus.{Failure, Partial, Success}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.EligibilityCheckDataResult
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.EligibilityCheckDataResult.EligibilityCheckDataResultBSP
+import uk.gov.hmrc.app.benefitEligibility.service.aggregation.AggregatedData.AggregatedDataBSP
+import uk.gov.hmrc.app.benefitEligibility.service.aggregation.ResultAggregation.ResultAggregator
+
+object AggregationServiceBSP {
+
+  val aggregator: ResultAggregator[EligibilityCheckDataResultBSP] =
+    (eligibilityCheckDataSuccessResultBSP: EligibilityCheckDataResultBSP) =>
+      if (eligibilityCheckDataSuccessResultBSP.overallResultStatus == Success) {
+
+        val marriageDetailsResult     = eligibilityCheckDataSuccessResultBSP.marriageDetailsResult
+        val marriageDetailsResultList = marriageDetailsResult.successResponse.flatMap(_.marriageDetailsList)
+
+        Right(
+          AggregatedDataBSP(
+            marriageDetailsResultList.flatMap(_.status).get,
+            marriageDetailsResultList.flatMap(_.startDate).get,
+            marriageDetailsResultList.flatMap(_.startDateStatus).get,
+            marriageDetailsResultList.flatMap(_.endDate).get,
+            marriageDetailsResultList.flatMap(_.endDateStatus).get,
+            marriageDetailsResultList.flatMap(_.spouseIdentifier).get,
+            marriageDetailsResultList.flatMap(_.spouseForename).get,
+            marriageDetailsResultList.flatMap(_.spouseSurname).get
+          )
+        )
+
+      } else if (eligibilityCheckDataSuccessResultBSP.overallResultStatus == Failure) {
+        Left(
+          BenefitEligibilityDataFetchError(
+            Failure,
+            BSP,
+            eligibilityCheckDataSuccessResultBSP.resultSummary,
+            eligibilityCheckDataSuccessResultBSP.allResults.filter(_.status == Failure)
+          )
+        )
+
+      } else {
+        Left(
+          BenefitEligibilityDataFetchError(
+            Partial,
+            BSP,
+            eligibilityCheckDataSuccessResultBSP.resultSummary,
+            eligibilityCheckDataSuccessResultBSP.allResults.filter(_.status == Success) ++
+              eligibilityCheckDataSuccessResultBSP.allResults.filter(_.status == Failure)
+          )
+        )
+      }
+
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/aggregators/AggregationServiceGYSP.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/aggregators/AggregationServiceGYSP.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.service.aggregation.aggregators
+
+import uk.gov.hmrc.app.benefitEligibility.common.BenefitEligibilityDataFetchError
+import uk.gov.hmrc.app.benefitEligibility.common.BenefitType.GYSP
+import uk.gov.hmrc.app.benefitEligibility.common.OverallResultStatus.{Failure, Partial, Success}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.EligibilityCheckDataResult
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.EligibilityCheckDataResult.EligibilityCheckDataResultGYSP
+import uk.gov.hmrc.app.benefitEligibility.service.aggregation.AggregatedData.AggregatedDataGYSP
+import uk.gov.hmrc.app.benefitEligibility.service.aggregation.ResultAggregation.ResultAggregator
+
+object AggregationServiceGYSP {
+
+  val aggregator: ResultAggregator[EligibilityCheckDataResultGYSP] =
+    (eligibilityCheckDataSuccessResultGYSP: EligibilityCheckDataResultGYSP) =>
+      if (eligibilityCheckDataSuccessResultGYSP.overallResultStatus == Success) {
+
+        val marriageDetailsResult     = eligibilityCheckDataSuccessResultGYSP.marriageDetailsResult
+        val marriageDetailsResultList = marriageDetailsResult.successResponse.flatMap(_.marriageDetailsList)
+
+        Right(
+          AggregatedDataGYSP(
+            marriageDetailsResultList.flatMap(_.status).get,
+            marriageDetailsResultList.flatMap(_.startDate).get,
+            marriageDetailsResultList.flatMap(_.startDateStatus).get,
+            marriageDetailsResultList.flatMap(_.endDate).get,
+            marriageDetailsResultList.flatMap(_.endDateStatus).get,
+            marriageDetailsResultList.flatMap(_.spouseIdentifier).get,
+            marriageDetailsResultList.flatMap(_.spouseForename).get,
+            marriageDetailsResultList.flatMap(_.spouseSurname).get
+          )
+        )
+
+      } else if (eligibilityCheckDataSuccessResultGYSP.overallResultStatus == Failure) {
+        Left(
+          BenefitEligibilityDataFetchError(
+            Failure,
+            GYSP,
+            eligibilityCheckDataSuccessResultGYSP.resultSummary,
+            eligibilityCheckDataSuccessResultGYSP.allResults.filter(_.status == Failure)
+          )
+        )
+
+      } else {
+        Left(
+          BenefitEligibilityDataFetchError(
+            Partial,
+            GYSP,
+            eligibilityCheckDataSuccessResultGYSP.resultSummary,
+            eligibilityCheckDataSuccessResultGYSP.allResults.filter(_.status == Success) ++
+              eligibilityCheckDataSuccessResultGYSP.allResults.filter(_.status == Failure)
+          )
+        )
+      }
+
+}

--- a/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/mapper/MarriageDetailsResponseMapperSpec.scala
+++ b/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/mapper/MarriageDetailsResponseMapperSpec.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.mapper
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers.shouldBe
+import uk.gov.hmrc.app.benefitEligibility.common.TextualErrorStatusCode.{
+  AccessForbidden,
+  BadRequest,
+  InternalServerError,
+  NotFound,
+  UnprocessableEntity
+}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResponseStatus.{Failure, Success}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResult.MarriageDetailsResult
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsError
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsError
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsError.ErrorCode403.ErrorCode403_2
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsError.ErrorReason403.Forbidden
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsError.{
+  MarriageDetailsErrorResponse400,
+  MarriageDetailsErrorResponse403,
+  MarriageDetailsErrorResponse422
+}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsSuccess.MarriageDetailsSuccessResponse
+
+class MarriageDetailsResponseMapperSpec extends AnyFreeSpec with MockFactory {
+
+  val mockMarriageDetailsSuccessResponse: MarriageDetailsSuccessResponse   = mock[MarriageDetailsSuccessResponse]
+  val mockMarriageDetailsErrorResponse400: MarriageDetailsErrorResponse400 = mock[MarriageDetailsErrorResponse400]
+  val mockMarriageDetailsErrorResponse403: MarriageDetailsErrorResponse403 = mock[MarriageDetailsErrorResponse403]
+  val mockMarriageDetailsErrorResponse422: MarriageDetailsErrorResponse422 = mock[MarriageDetailsErrorResponse422]
+
+  val underTest = new MarriageDetailsResponseMapper
+
+  "MarriageDetailsResponseMapper" - {
+    ".toResult" - {
+      "should successfully return a Success result when given a SuccessResponse" in {
+
+        underTest.toResult(mockMarriageDetailsSuccessResponse) shouldBe
+          MarriageDetailsResult(Success, Some(mockMarriageDetailsSuccessResponse), None)
+      }
+
+      "should successfully return a Failure result when given an ErrorResponse400" in {
+
+        (() => mockMarriageDetailsErrorResponse400._1).expects().returning(List.empty)
+
+        underTest.toResult(mockMarriageDetailsErrorResponse400) shouldBe
+          MarriageDetailsResult(
+            Failure,
+            None,
+            Some(NpsError(code = BadRequest, message = "", downstreamStatus = 400))
+          )
+      }
+
+      "should successfully return a Failure result when given a ErrorResponse403" in {
+
+        (() => mockMarriageDetailsErrorResponse403._1).expects().returning(Forbidden)
+        (() => mockMarriageDetailsErrorResponse403._2).expects().returning(ErrorCode403_2)
+
+        underTest.toResult(mockMarriageDetailsErrorResponse403) shouldBe
+          MarriageDetailsResult(
+            Failure,
+            None,
+            Some(NpsError(code = AccessForbidden, message = "Forbidden", downstreamStatus = 403))
+          )
+      }
+
+      "should successfully return a Failure result when given a ErrorResponse422" in {
+
+        (() => mockMarriageDetailsErrorResponse422._1).expects().returning(List.empty)
+
+        underTest.toResult(mockMarriageDetailsErrorResponse422) shouldBe
+          MarriageDetailsResult(
+            Failure,
+            None,
+            Some(
+              NpsError(
+                code = UnprocessableEntity,
+                message = "",
+                downstreamStatus = 422
+              )
+            )
+          )
+      }
+    }
+
+    "should successfully return a Failure result when given an UnprocessableEntity TextualErrorStatusCode" in {
+
+      underTest.toResult(UnprocessableEntity) shouldBe
+        MarriageDetailsResult(
+          Failure,
+          None,
+          Some(
+            NpsError(
+              UnprocessableEntity,
+              UnprocessableEntity.message,
+              UnprocessableEntity.code
+            )
+          )
+        )
+    }
+
+    "should successfully return a Failure result when given a BadRequest TextualErrorStatusCode" in {
+
+      underTest.toResult(BadRequest) shouldBe
+        MarriageDetailsResult(
+          Failure,
+          None,
+          Some(
+            NpsError(
+              BadRequest,
+              BadRequest.message,
+              BadRequest.code
+            )
+          )
+        )
+    }
+
+    "should successfully return a Failure result when given an AccessForbidden TextualErrorStatusCode" in {
+
+      underTest.toResult(AccessForbidden) shouldBe
+        MarriageDetailsResult(
+          Failure,
+          None,
+          Some(
+            NpsError(
+              AccessForbidden,
+              AccessForbidden.message,
+              AccessForbidden.code
+            )
+          )
+        )
+    }
+
+    "should successfully return a Failure result when given a NotFound TextualErrorStatusCode" in {
+
+      underTest.toResult(NotFound) shouldBe
+        MarriageDetailsResult(
+          Failure,
+          None,
+          Some(
+            NpsError(
+              NotFound,
+              NotFound.message,
+              NotFound.code
+            )
+          )
+        )
+    }
+
+    "should successfully return a Failure result when given an InternalServerError TextualErrorStatusCode" in {
+
+      underTest.toResult(InternalServerError) shouldBe
+        MarriageDetailsResult(
+          Failure,
+          None,
+          Some(
+            NpsError(
+              InternalServerError,
+              InternalServerError.message,
+              InternalServerError.code
+            )
+          )
+        )
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/request/MarriageDetailsRequestHelperSpec.scala
+++ b/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/marriageDetails/model/request/MarriageDetailsRequestHelperSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.request
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers.shouldBe
+import uk.gov.hmrc.app.benefitEligibility.common.Identifier
+import uk.gov.hmrc.app.benefitEligibility.integration.inbound.{
+  BSPEligibilityCheckDataRequest,
+  GYSPEligibilityCheckDataRequest
+}
+import uk.gov.hmrc.app.config.AppConfig
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import java.time.LocalDate
+import scala.language.postfixOps
+
+class MarriageDetailsRequestHelperSpec extends AnyFreeSpec with MockFactory {
+
+  val mockServicesConfig: ServicesConfig = mock[ServicesConfig]
+
+  (mockServicesConfig.baseUrl(_: String)).expects("hip").returning("hip")
+  (mockServicesConfig.getString(_: String)).expects("microservice.services.hip.originatorId").returning("originatorId")
+  (mockServicesConfig.getString(_: String)).expects("microservice.services.hip.clientId").returning("clientId")
+  (mockServicesConfig.getString(_: String)).expects("microservice.services.hip.clientSecret").returning("clientSecret")
+
+  val appConfig: AppConfig = new AppConfig(config = mockServicesConfig)
+
+  val underTest = new MarriageDetailsRequestHelper()
+
+  private val eligibilityCheckDataRequestBSP = BSPEligibilityCheckDataRequest(
+    nationalInsuranceNumber = "GD379251T",
+    dateOfBirth = LocalDate.parse("1992-08-23"),
+    startTaxYear = 2025,
+    endTaxYear = 2025,
+    identifier = Identifier("GD379251T"),
+    searchStartYear = Some(2025),
+    searchEndYear = Some(2025),
+    latest = Some(true),
+    sequence = Some(23)
+  )
+
+  private val eligibilityCheckDataRequestGYSP = GYSPEligibilityCheckDataRequest(
+    nationalInsuranceNumber = "GD379251T",
+    dateOfBirth = LocalDate.parse("1992-08-23"),
+    startTaxYear = 2025,
+    endTaxYear = 2025,
+    identifier = Identifier("GD379251T"),
+    searchStartYear = Some(2025),
+    searchEndYear = Some(2025),
+    latest = Some(true),
+    sequence = Some(23),
+    associatedCalculationSequenceNumber = 1123232,
+    benefitType = "SOME BENEFIT",
+    pensionProcessingArea = Some("pensionProcessingArea"),
+    schemeContractedOutNumber = 32324343,
+    schemeMembershipSequenceNumber = Some(4343343),
+    schemeMembershipTransferSequenceNumber = Some(435454545),
+    schemeMembershipOccurrenceNumber = Some(3289908)
+  )
+
+  private val expectedRequestUrl =
+    "hip/ni/individual/Identifier(GD379251T)/marriage-cpSome(searchStartYear=2025&searchEndYear=2025&latest=true&?sequence=23)/"
+
+  "MarriageDetailsRequestHelper" - {
+    ".buildRequestPath" - {
+      "should build request path successfully when given BSP request" in {
+
+        underTest
+          .buildRequestPath(appConfig.hipBaseUrl, eligibilityCheckDataRequestBSP) shouldBe expectedRequestUrl
+      }
+
+      "should build request path successfully when given GYSP request" in {
+
+        underTest
+          .buildRequestPath(appConfig.hipBaseUrl, eligibilityCheckDataRequestGYSP) shouldBe expectedRequestUrl
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/app/benefitEligibility/service/BspDataRetrievalServiceSpec.scala
+++ b/test/uk/gov/hmrc/app/benefitEligibility/service/BspDataRetrievalServiceSpec.scala
@@ -23,9 +23,9 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers.*
 import uk.gov.hmrc.app.benefitEligibility.common.*
 import uk.gov.hmrc.app.benefitEligibility.common.TextualErrorStatusCode.AccessForbidden
-import uk.gov.hmrc.app.benefitEligibility.integration.inbound.GYSPEligibilityCheckDataRequest
+import uk.gov.hmrc.app.benefitEligibility.integration.inbound.BSPEligibilityCheckDataRequest
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.{EligibilityCheckDataResult, NpsError}
-import uk.gov.hmrc.app.benefitEligibility.integration.outbound.EligibilityCheckDataResult.EligibilityCheckDataResultGYSP
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.EligibilityCheckDataResult.EligibilityCheckDataResultBSP
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResponseStatus.Failure
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.NpsApiResult.MarriageDetailsResult
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.connector.MarriageDetailsConnector
@@ -38,7 +38,7 @@ import java.time.LocalDate
 import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 
-class GetYourStatePensionDataRetrievalServiceSpec extends AnyFreeSpec with MockFactory {
+class BspDataRetrievalServiceSpec extends AnyFreeSpec with MockFactory {
 
   private implicit val hc: HeaderCarrier = HeaderCarrier()
 
@@ -57,13 +57,13 @@ class GetYourStatePensionDataRetrievalServiceSpec extends AnyFreeSpec with MockF
 
   val appConfig: AppConfig = new AppConfig(config = mockServicesConfig)
 
-  val underTest = new GetYourStatePensionDataRetrievalService(
+  val underTest = new BspDataRetrievalService(
     mockMarriageDetailsConnector,
     mockMarriageDetailsRequestHelper,
     appConfig
   )
 
-  private val eligibilityCheckDataRequest = GYSPEligibilityCheckDataRequest(
+  private val eligibilityCheckDataRequest = BSPEligibilityCheckDataRequest(
     nationalInsuranceNumber = "GD379251T",
     dateOfBirth = LocalDate.parse("1992-08-23"),
     startTaxYear = 2025,
@@ -72,20 +72,13 @@ class GetYourStatePensionDataRetrievalServiceSpec extends AnyFreeSpec with MockF
     searchStartYear = Some(2025),
     searchEndYear = Some(2025),
     latest = Some(true),
-    sequence = Some(12),
-    associatedCalculationSequenceNumber = 1123232,
-    benefitType = "SOME BENEFIT",
-    pensionProcessingArea = Some("pensionProcessingArea"),
-    schemeContractedOutNumber = 32324343,
-    schemeMembershipSequenceNumber = Some(4343343),
-    schemeMembershipTransferSequenceNumber = Some(435454545),
-    schemeMembershipOccurrenceNumber = Some(3289908)
+    sequence = Some(23)
   )
 
   private val marriageDetailsResult =
     MarriageDetailsResult(Failure, None, Some(NpsError(AccessForbidden, "", 403)))
 
-  "GetYourStatePensionDataRetrievalService" - {
+  "BspDataRetrievalService" - {
     ".fetchEligibilityData" - {
       "should retrieve data successfully" in {
 
@@ -99,14 +92,14 @@ class GetYourStatePensionDataRetrievalServiceSpec extends AnyFreeSpec with MockF
           )
 
         (mockMarriageDetailsRequestHelper
-          .buildRequestPath(_: String, _: GYSPEligibilityCheckDataRequest))
+          .buildRequestPath(_: String, _: BSPEligibilityCheckDataRequest))
           .expects("hip", eligibilityCheckDataRequest)
           .returning("some url path")
 
         underTest
           .fetchEligibilityData(eligibilityCheckDataRequest)
           .value
-          .futureValue shouldBe Right(EligibilityCheckDataResultGYSP(marriageDetailsResult))
+          .futureValue shouldBe Right(EligibilityCheckDataResultBSP(marriageDetailsResult))
 
       }
     }


### PR DESCRIPTION
Adds relevant models and endpoint structure for marriage details endpoint for NPS calls as well as integration with GYSP and BSP requests and responses.