### PR TITLE
DWPDAT-82: Add models for individual state pension API

### DIFF
--- a/app/uk/gov/hmrc/app/benefitEligibility/common/HipOriginResponse.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/common/HipOriginResponse.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.common
+
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
+import play.api.libs.json.{Format, Json}
+
+import scala.collection.immutable
+
+sealed abstract class HipOrigin(override val entryName: String) extends EnumEntry
+
+object HipOrigin extends Enum[HipOrigin] with PlayJsonEnum[HipOrigin] {
+  val values: immutable.IndexedSeq[HipOrigin] = findValues
+
+  case object Hip extends HipOrigin("HIP")
+
+  case object HoD extends HipOrigin("HoD")
+}
+
+case class FailureType(value: String) extends AnyVal
+
+object FailureType {
+  implicit val reads: Format[FailureType] = Json.valueFormat[FailureType]
+}
+
+case class HipFailureItem(
+    `type`: FailureType,
+    reason: Reason
+)
+
+object HipFailureItem {
+  implicit val reads: Format[HipFailureItem] = Json.format[HipFailureItem]
+}
+
+case class HipFailureResponse(
+    failures: List[HipFailureItem]
+)
+
+object HipFailureResponse {
+  implicit val reads: Format[HipFailureResponse] = Json.format[HipFailureResponse]
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/common/NpsError.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/common/NpsError.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.common
+
+import play.api.libs.json.{Json, Reads}
+
+final case class ErrorCode(value: String) extends AnyVal
+
+object ErrorCode {
+  implicit val reads: Reads[ErrorCode] = Json.valueReads[ErrorCode]
+}
+
+case class NpsError(reason: Reason, code: ErrorCode)

--- a/app/uk/gov/hmrc/app/benefitEligibility/common/NpsErrorCode.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/common/NpsErrorCode.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.common
+
+import play.api.libs.json.{Json, Reads}
+
+final case class NpsErrorCode(value: String) extends AnyVal
+
+object NpsErrorCode {
+  implicit val reads: Reads[NpsErrorCode] = Json.valueReads[NpsErrorCode]
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/common/TaxYear.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/common/TaxYear.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.common
+
+import play.api.libs.json.{Format, Json}
+
+case class TaxYear(value: Int) extends AnyVal
+
+object TaxYear {
+  implicit val weeksPaidReads: Format[TaxYear] = Json.valueFormat[TaxYear]
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/IndividualStatePensionInformationResponse.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/IndividualStatePensionInformationResponse.scala
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response
+
+import play.api.libs.json.{Format, Json, Reads}
+import uk.gov.hmrc.app.benefitEligibility.common.*
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.{NpsApiResponse, NpsSuccessfulApiResponse}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.enums.{
+  ContributionCreditType,
+  CreditSourceType
+}
+
+import scala.collection.immutable
+
+sealed trait IndividualStatePensionInformationResponse extends NpsApiResponse
+
+object IndividualStatePensionInformationError {
+
+  // 400 start
+  sealed trait IndividualStatePensionInformationErrorResponse400 extends IndividualStatePensionInformationResponse
+
+  case class ErrorResourceObj400(
+      reason: Reason,
+      code: NpsErrorCode400
+  )
+
+  object ErrorResourceObj400 {
+    implicit val errorResourceObj400Reads: Reads[ErrorResourceObj400] = Json.reads[ErrorResourceObj400]
+  }
+
+  case class HipFailureResponse400(origin: HipOrigin, response: HipFailureResponse)
+      extends IndividualStatePensionInformationErrorResponse400
+
+  object HipFailureResponse400 {
+    implicit val hipFailureResponse400Reads: Reads[HipFailureResponse400] = Json.reads[HipFailureResponse400]
+  }
+
+  case class ErrorResponse400(failures: List[ErrorResourceObj400])
+
+  object ErrorResponse400 {
+    implicit val errorResponse400Reads: Reads[ErrorResponse400] = Json.reads[ErrorResponse400]
+  }
+
+  case class StandardErrorResponse400(origin: HipOrigin, response: ErrorResponse400)
+      extends IndividualStatePensionInformationErrorResponse400
+
+  object StandardErrorResponse400 {
+    implicit val standardErrorResponse400Reads: Reads[StandardErrorResponse400] = Json.reads[StandardErrorResponse400]
+  }
+  // 400 end
+
+  // 403 start
+  case class IndividualStatePensionInformationErrorResponse403(
+      reason: NpsErrorReason403,
+      code: NpsErrorCode403
+  ) extends IndividualStatePensionInformationResponse
+
+  object IndividualStatePensionInformationErrorResponse403 {
+
+    implicit val individualStatePensionInformationErrorResponse403Reads
+        : Format[IndividualStatePensionInformationErrorResponse403] =
+      Json.format[IndividualStatePensionInformationErrorResponse403]
+
+  }
+
+  // 503 start
+  case class IndividualStatePensionInformationErrorResponse503(
+      origin: HipOrigin,
+      response: HipFailureResponse
+  ) extends IndividualStatePensionInformationResponse
+
+  object IndividualStatePensionInformationErrorResponse503 {
+
+    implicit val individualStatePensionInformationErrorResponse503Reads
+        : Reads[IndividualStatePensionInformationErrorResponse503] =
+      Json.reads[IndividualStatePensionInformationErrorResponse503]
+
+  }
+  // 503 end
+
+}
+
+object IndividualStatePensionInformationSuccess {
+
+  case class NumberOfQualifyingYears(value: Int) extends AnyVal
+
+  object NumberOfQualifyingYears {
+    implicit val reads: Format[NumberOfQualifyingYears] = Json.valueFormat[NumberOfQualifyingYears]
+  }
+
+  case class NonQualifyingYears(value: Int) extends AnyVal
+
+  object NonQualifyingYears {
+    implicit val reads: Format[NonQualifyingYears] = Json.valueFormat[NonQualifyingYears]
+  }
+
+  case class YearsToFinalRelevantYear(value: Int) extends AnyVal
+
+  object YearsToFinalRelevantYear {
+    implicit val reads: Format[YearsToFinalRelevantYear] = Json.valueFormat[YearsToFinalRelevantYear]
+  }
+
+  case class NonQualifyingYearsPayable(value: Int) extends AnyVal
+
+  object NonQualifyingYearsPayable {
+    implicit val reads: Format[NonQualifyingYearsPayable] = Json.valueFormat[NonQualifyingYearsPayable]
+  }
+
+  case class Pre1975CCCount(value: Int) extends AnyVal
+
+  object Pre1975CCCount {
+    implicit val reads: Format[Pre1975CCCount] = Json.valueFormat[Pre1975CCCount]
+  }
+
+  case class DateOfEntry(value: String) extends AnyVal
+
+  object DateOfEntry {
+    implicit val reads: Format[DateOfEntry] = Json.valueFormat[DateOfEntry]
+  }
+
+  case class QualifyingTaxYear(value: Boolean) extends AnyVal
+
+  object QualifyingTaxYear {
+    implicit val reads: Format[QualifyingTaxYear] = Json.valueFormat[QualifyingTaxYear]
+  }
+
+  case class PayableAccepted(value: Boolean) extends AnyVal
+
+  object PayableAccepted {
+    implicit val reads: Format[PayableAccepted] = Json.valueFormat[PayableAccepted]
+  }
+
+  case class AmountNeeded(value: BigDecimal) extends AnyVal
+
+  object AmountNeeded {
+    implicit val reads: Format[AmountNeeded] = Json.valueFormat[AmountNeeded]
+  }
+
+  case class ClassThreePayable(value: BigDecimal) extends AnyVal
+
+  object ClassThreePayable {
+    implicit val reads: Format[ClassThreePayable] = Json.valueFormat[ClassThreePayable]
+  }
+
+  case class ClassThreePayableBy(value: String) extends AnyVal
+
+  object ClassThreePayableBy {
+    implicit val reads: Format[ClassThreePayableBy] = Json.valueFormat[ClassThreePayableBy]
+  }
+
+  case class ClassThreePayableByPenalty(value: String) extends AnyVal
+
+  object ClassThreePayableByPenalty {
+    implicit val reads: Format[ClassThreePayableByPenalty] = Json.valueFormat[ClassThreePayableByPenalty]
+  }
+
+  case class ClassTwoPayable(value: BigDecimal) extends AnyVal
+
+  object ClassTwoPayable {
+    implicit val reads: Format[ClassTwoPayable] = Json.valueFormat[ClassTwoPayable]
+  }
+
+  case class ClassTwoPayableBy(value: String) extends AnyVal
+
+  object ClassTwoPayableBy {
+    implicit val reads: Format[ClassTwoPayableBy] = Json.valueFormat[ClassTwoPayableBy]
+  }
+
+  case class ClassTwoPayableByPenalty(value: String) extends AnyVal
+
+  object ClassTwoPayableByPenalty {
+    implicit val reads: Format[ClassTwoPayableByPenalty] = Json.valueFormat[ClassTwoPayableByPenalty]
+  }
+
+  case class ClassTwoOutstandingWeeks(value: Int) extends AnyVal
+
+  object ClassTwoOutstandingWeeks {
+    implicit val reads: Format[ClassTwoOutstandingWeeks] = Json.valueFormat[ClassTwoOutstandingWeeks]
+  }
+
+  case class TotalPrimaryContributions(value: BigDecimal) extends AnyVal
+
+  object TotalPrimaryContributions {
+    implicit val reads: Format[TotalPrimaryContributions] = Json.valueFormat[TotalPrimaryContributions]
+  }
+
+  case class NiEarnings(value: BigDecimal) extends AnyVal
+
+  object NiEarnings {
+    implicit val reads: Format[NiEarnings] = Json.valueFormat[NiEarnings]
+  }
+
+  case class CoClassOnePaid(value: BigDecimal) extends AnyVal
+
+  object CoClassOnePaid {
+    implicit val reads: Format[CoClassOnePaid] = Json.valueFormat[CoClassOnePaid]
+  }
+
+  case class TotalPrimaryEarnings(value: BigDecimal) extends AnyVal
+
+  object TotalPrimaryEarnings {
+    implicit val reads: Format[TotalPrimaryEarnings] = Json.valueFormat[TotalPrimaryEarnings]
+  }
+
+  case class NiEarningsSelfEmployed(value: Int) extends AnyVal
+
+  object NiEarningsSelfEmployed {
+    implicit val reads: Format[NiEarningsSelfEmployed] = Json.valueFormat[NiEarningsSelfEmployed]
+  }
+
+  case class NiEarningsVoluntary(value: Int) extends AnyVal
+
+  object NiEarningsVoluntary {
+    implicit val reads: Format[NiEarningsVoluntary] = Json.valueFormat[NiEarningsVoluntary]
+  }
+
+  case class UnderInvestigationFlag(value: Boolean) extends AnyVal
+
+  object UnderInvestigationFlag {
+    implicit val reads: Format[UnderInvestigationFlag] = Json.valueFormat[UnderInvestigationFlag]
+  }
+
+  case class PrimaryPaidEarnings(value: BigDecimal) extends AnyVal
+
+  object PrimaryPaidEarnings {
+    implicit val reads: Format[PrimaryPaidEarnings] = Json.valueFormat[PrimaryPaidEarnings]
+  }
+
+  case class ContributionCreditCount(value: Int) extends AnyVal
+
+  object ContributionCreditCount {
+    implicit val reads: Format[ContributionCreditCount] = Json.valueFormat[ContributionCreditCount]
+  }
+
+  case class OtherCredits(
+      contributionCreditType: Option[ContributionCreditType],
+      creditSourceType: Option[CreditSourceType],
+      contributionCreditCount: Option[ContributionCreditCount]
+  )
+
+  object OtherCredits {
+    implicit val reads: Format[OtherCredits] = Json.format[OtherCredits]
+  }
+
+  case class ContributionsByTaxYear(
+      taxYear: Option[TaxYear],
+      qualifyingTaxYear: Option[QualifyingTaxYear],
+      payableAccepted: Option[PayableAccepted],
+      amountNeeded: Option[AmountNeeded],
+      classThreePayable: Option[ClassThreePayable],
+      classThreePayableBy: Option[ClassThreePayableBy],
+      classThreePayableByPenalty: Option[ClassThreePayableByPenalty],
+      classTwoPayable: Option[ClassTwoPayable],
+      classTwoPayableBy: Option[ClassTwoPayableBy],
+      classTwoPayableByPenalty: Option[ClassTwoPayableByPenalty],
+      classTwoOutstandingWeeks: Option[ClassTwoOutstandingWeeks],
+      totalPrimaryContributions: Option[TotalPrimaryContributions],
+      niEarnings: Option[NiEarnings],
+      coClassOnePaid: Option[CoClassOnePaid],
+      totalPrimaryEarnings: Option[TotalPrimaryEarnings],
+      niEarningsSelfEmployed: Option[NiEarningsSelfEmployed],
+      niEarningsVoluntary: Option[NiEarningsVoluntary],
+      underInvestigationFlag: Option[UnderInvestigationFlag],
+      primaryPaidEarnings: Option[PrimaryPaidEarnings],
+      otherCredits: Option[List[OtherCredits]]
+  )
+
+  object ContributionsByTaxYear {
+    implicit val reads: Format[ContributionsByTaxYear] = Json.format[ContributionsByTaxYear]
+  }
+
+  case class IndividualStatePensionInformationSuccessResponse(
+      identifier: Identifier,
+      numberOfQualifyingYears: Option[NumberOfQualifyingYears],
+      nonQualifyingYears: Option[NonQualifyingYears],
+      yearsToFinalRelevantYear: Option[YearsToFinalRelevantYear],
+      nonQualifyingYearsPayable: Option[NonQualifyingYearsPayable],
+      pre1975CCCount: Option[Pre1975CCCount],
+      dateOfEntry: Option[DateOfEntry],
+      contributionsByTaxYear: Option[List[ContributionsByTaxYear]]
+  ) extends IndividualStatePensionInformationResponse
+      with NpsSuccessfulApiResponse
+
+  object IndividualStatePensionInformationSuccessResponse {
+
+    implicit val reads: Format[IndividualStatePensionInformationSuccessResponse] =
+      Json.format[IndividualStatePensionInformationSuccessResponse]
+
+  }
+
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/IndividualStatePensionInformationResponseValidation.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/IndividualStatePensionInformationResponseValidation.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response
+
+import cats.implicits.{catsSyntaxNestedFoldable, toFunctorOps}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.IndividualStatePensionInformationSuccess.IndividualStatePensionInformationSuccessResponse
+import uk.gov.hmrc.app.benefitEligibility.util.validation.{MoneyValidation, NumberValidation}
+import uk.gov.hmrc.app.benefitEligibility.util.{NpsResponseValidator, SuccessfulResult}
+
+object IndividualStatePensionInformationResponseValidation {
+
+  implicit val individualStatePensionInformationResponseValidator
+      : NpsResponseValidator[IndividualStatePensionInformationSuccessResponse] =
+    (_, response: IndividualStatePensionInformationSuccessResponse) =>
+      (List(response.numberOfQualifyingYears.map(n => NumberValidation.validate(n, 0, 100))).flatten ++
+        (response.contributionsByTaxYear match {
+          case Some(contributionsByTaxYear) =>
+            contributionsByTaxYear.flatMap { el =>
+              List(
+                el.primaryPaidEarnings.map(p =>
+                  MoneyValidation.validate(p, MoneyValidation.Defaults.signedMin, 2, BigDecimal("0.01"))
+                )
+              ).flatten
+            }
+          case None => List()
+        })).sequence_.as(SuccessfulResult)
+
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/enums/ContributionCreditType.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/enums/ContributionCreditType.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.enums
+
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
+import scala.collection.immutable
+
+sealed abstract class ContributionCreditType(override val entryName: String) extends EnumEntry
+
+object ContributionCreditType extends Enum[ContributionCreditType] with PlayJsonEnum[ContributionCreditType] {
+  val values: immutable.IndexedSeq[ContributionCreditType] = findValues
+
+  case object NotKnown extends ContributionCreditType("NOT KNOWN")
+
+  case object Class1NormalDeductionCard extends ContributionCreditType("CLASS 1 - NORMAL DEDUCTION CARD")
+
+  case object Class1Hmf extends ContributionCreditType("CLASS 1- HMF")
+
+  case object Class1Mariner extends ContributionCreditType("CLASS 1- MARINER")
+
+  case object Class1CivilServantFringeBody extends ContributionCreditType("CLASS 1- CIVIL SERVANT/FRINGE BODY")
+
+  case object Class1EmployeeOnly extends ContributionCreditType("CLASS 1- EMPLOYEE ONLY")
+
+  case object Class2NormalRate extends ContributionCreditType("CLASS 2 - NORMAL RATE")
+
+  case object Class2WomansRate extends ContributionCreditType("CLASS 2 - WOMAN'S RATE")
+
+  case object Class2SharefishermansRate extends ContributionCreditType("CLASS 2 - SHAREFISHERMAN'S RATE")
+
+  case object Class2NormalRateA extends ContributionCreditType("CLASS 2 - NORMAL RATE A")
+
+  case object Class2NormalRateB extends ContributionCreditType("CLASS 2 - NORMAL RATE B")
+
+  case object Class2NormalRateC extends ContributionCreditType("CLASS 2 - NORMAL RATE C")
+
+  case object Class2NormalRateD extends ContributionCreditType("CLASS 2 - NORMAL RATE D")
+
+  case object Class2SharefishermansRateA extends ContributionCreditType("CLASS 2 - SHAREFISHERMAN'S RATE A")
+
+  case object Class2SharefishermansRateB extends ContributionCreditType("CLASS 2 - SHAREFISHERMAN'S RATE B")
+
+  case object Class2SharefishermansRateC extends ContributionCreditType("CLASS 2 - SHAREFISHERMAN'S RATE C")
+
+  case object Class2SharefishermansRateD extends ContributionCreditType("CLASS 2 - SHAREFISHERMAN'S RATE D")
+
+  case object Class2VoluntaryDevelopmentWorkerRateA
+      extends ContributionCreditType("CLASS 2 - VOLUNTARY DEVELOPMENT WORKER'S RATE A")
+
+  case object Class3Pre85Rate extends ContributionCreditType("CLASS 3 - PRE 85 RATE")
+
+  case object Class3RateA extends ContributionCreditType("CLASS 3 - RATE A")
+
+  case object Class3RateB extends ContributionCreditType("CLASS 3 - RATE B")
+
+  case object Class3RateC extends ContributionCreditType("CLASS 3 - RATE C")
+
+  case object Class3RateD extends ContributionCreditType("CLASS 3 - RATE D")
+
+  case object Class1Credit extends ContributionCreditType("CLASS 1 CREDIT")
+
+  case object Class3Credit extends ContributionCreditType("CLASS 3 CREDIT")
+
+  case object NotApplicable extends ContributionCreditType("NOT APPLICABLE")
+
+  case object Class2VoluntaryDevelopmentWorkerRateB
+      extends ContributionCreditType("CLASS 2 - VOLUNTARY DEVELOPMENT WORKER'S RATE B")
+
+  case object Class2VoluntaryDevelopmentWorkerRateC
+      extends ContributionCreditType("CLASS 2 - VOLUNTARY DEVELOPMENT WORKER'S RATE C")
+
+  case object Class2VoluntaryDevelopmentWorkerRateD
+      extends ContributionCreditType("CLASS 2 - VOLUNTARY DEVELOPMENT WORKER'S RATE D")
+
+  case object Class2ContributionConvertedFromNirs1
+      extends ContributionCreditType("CLASS 2 - CONTRIBUTION CONVERTED FROM NIRS1")
+
+  case object Class3ContributionConvertedFromNirs1
+      extends ContributionCreditType("CLASS 3 - CONTRIBUTION CONVERTED FROM NIRS1")
+
+  case object CreditConvertedFromNirs1 extends ContributionCreditType("CREDIT CONVERTED FROM NIRS1")
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/enums/CreditSourceType.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/enums/CreditSourceType.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.enums
+
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
+
+import scala.collection.immutable
+
+sealed abstract class CreditSourceType(override val entryName: String) extends EnumEntry
+
+object CreditSourceType extends Enum[CreditSourceType] with PlayJsonEnum[CreditSourceType] {
+  val values: immutable.IndexedSeq[CreditSourceType] = findValues
+
+  case object NotKnown extends CreditSourceType("NOT KNOWN")
+
+  case object AdpCentreLivingston extends CreditSourceType("ADP CENTRE LIVINGSTON")
+
+  case object DssLocalOffices extends CreditSourceType("DSS LOCAL OFFICES")
+
+  case object EmploymentServices extends CreditSourceType("EMPLOYMENT SERVICES")
+
+  case object DirectDebit extends CreditSourceType("DIRECT DEBIT")
+
+  case object CarersAllowance extends CreditSourceType("CARER'S ALLOWANCE (CA)")
+
+  case object HncipOrSda extends CreditSourceType("HNCIP OR SDA")
+
+  case object NorthernIrelandSicknessCredits extends CreditSourceType("NORTHERN IRELAND SICKNESS CREDITS")
+
+  case object JuryService extends CreditSourceType("JURY SERVICE")
+
+  case object Nubs2 extends CreditSourceType("NUBS 2")
+
+  case object Nubs2AlternativeSbConditionMet extends CreditSourceType("NUBS 2 [ALTERNATIVE SB CONDITION MET]")
+
+  case object DwaUnitBlackpoolEmployedEarners extends CreditSourceType("DWA UNIT (BLACKPOOL) EMPLOYED EARNERS")
+
+  case object DwaUnitBlackpoolSelfEmployedEarners extends CreditSourceType("DWA UNIT (BLACKPOOL) SELF EMPLOYED EARNERS")
+
+  case object DwaUnitBelfastEmployedEarners extends CreditSourceType("DWA UNIT (BELFAST) EMPLOYED EARNERS")
+
+  case object DwaUnitBelfastSelfEmployedEarners extends CreditSourceType("DWA UNIT (BELFAST) SELF EMPLOYED EARNERS")
+
+  case object IsleOfMan extends CreditSourceType("ISLE OF MAN")
+
+  case object AutocreditsInternallyCalculated extends CreditSourceType("AUTOCREDITS - INTERNALLY CALCULATED")
+
+  case object AutocreditsExternallyInput extends CreditSourceType("AUTOCREDITS - EXTERNALLY INPUT")
+
+  case object JuvenileCreditsInternal extends CreditSourceType("JUVENILE CREDITS (INTERNAL)")
+
+  case object WidowsCreditsInternal extends CreditSourceType("WIDOWS CREDITS (INTERNAL)")
+
+  case object ApprovedTrainingCreditsInternal extends CreditSourceType("APPROVED TRAINING CREDITS (INTERNAL)")
+
+  case object UnemployabilitySupplementCreditsInternal
+      extends CreditSourceType("UNEMPLOYABILITY SUPPLEMENT CREDITS (INTERNAL)")
+
+  case object PscsIncap extends CreditSourceType("PSCS INCAP")
+
+  case object LongTermScaleRate extends CreditSourceType("LONG TERM SCALE RATE")
+
+  case object AdpReading extends CreditSourceType("ADP READING")
+
+  case object NotApplicable extends CreditSourceType("NOT APPLICABLE")
+
+  case object QuarterlyBilling extends CreditSourceType("QUARTERLY BILLING")
+
+  case object JsaTapeInput extends CreditSourceType("JSA TAPE INPUT")
+
+  case object JsaTapeInputAlternativeSbConditionMet
+      extends CreditSourceType("JSA TAPE INPUT (ALTERNATIVE SB CONDITION MET)")
+
+  case object JsaPaperInput extends CreditSourceType("JSA PAPER INPUT")
+
+  case object FamcNi extends CreditSourceType("FAMC-NI")
+
+  case object FamcGb extends CreditSourceType("FAMC-GB")
+
+  case object CentralAward extends CreditSourceType("CENTRAL AWARD")
+
+  case object AdpNorthernIreland extends CreditSourceType("ADP NORTHERN IRELAND")
+
+  case object FamilyCreditGb extends CreditSourceType("FAMILY CREDIT (GB)")
+
+  case object FamilyCreditNi extends CreditSourceType("FAMILY CREDIT (NI)")
+
+  case object Incapacity extends CreditSourceType("INCAPACITY")
+
+  case object DptcGbEmp extends CreditSourceType("DPTC (GB) EMP")
+
+  case object DptcGbSEmp extends CreditSourceType("DPTC (GB) S/EMP")
+
+  case object DptcNiEmp extends CreditSourceType("DPTC (NI) EMP")
+
+  case object DptcNiSEmp extends CreditSourceType("DPTC (NI) S/EMP")
+
+  case object WftcGb extends CreditSourceType("WFTC (GB)")
+
+  case object WftcNi extends CreditSourceType("WFTC (NI)")
+
+  case object StatutoryMaternityPayCredit extends CreditSourceType("STATUTORY MATERNITY PAY CREDIT")
+
+  case object StatutoryAdoptionPayCredit extends CreditSourceType("STATUTORY ADOPTION PAY CREDIT")
+
+  case object DisabledTaxCreditEmployed extends CreditSourceType("DISABLED TAX CREDIT (EMPLOYED)")
+
+  case object DisabledTaxCreditSelfEmployed extends CreditSourceType("DISABLED TAX CREDIT (SELF-EMPLOYED)")
+
+  case object WorkingTaxCreditEmployed extends CreditSourceType("WORKING TAX CREDIT (EMPLOYED)")
+
+  case object WorkingTaxCreditSelfEmployed extends CreditSourceType("WORKING TAX CREDIT (SELF-EMPLOYED)")
+
+  case object EmploymentAndSupport extends CreditSourceType("EMPLOYMENT AND SUPPORT")
+
+  case object HrpConversion extends CreditSourceType("HRP CONVERSION")
+
+  case object ChildBenefit extends CreditSourceType("CHILD BENEFIT")
+
+  case object CarersCredit extends CreditSourceType("CARER'S CREDIT")
+
+  case object FosterCarer extends CreditSourceType("FOSTER CARER")
+
+  case object ModSpouseCivilPartnersCredits extends CreditSourceType("MOD SPOUSE/CIVIL PARTNER'S CREDITS")
+
+  case object AdditionalStatutoryPaternityPay extends CreditSourceType("ADDITTIONAL STATUTORY PATERNITY PAY")
+
+  case object SpecifiedAdultCarer extends CreditSourceType("SPECIFIED ADULT CARER")
+
+  case object UniversalCredit extends CreditSourceType("UNIVERSAL CREDIT")
+
+  case object SharedParentalPay extends CreditSourceType("SHARED PARENTAL PAY")
+
+  case object Post75ServiceSpousesCredit extends CreditSourceType("POST 75 SERVICE SPOUSES CREDIT")
+
+  case object StatutoryParentalBereavementPay extends CreditSourceType("STATUTORY PARENTAL BEREAVEMENT PAY")
+}

--- a/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/niContributionsAndCredits/model/response/NiContributionsAndCreditsResponse.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/integration/outbound/niContributionsAndCredits/model/response/NiContributionsAndCreditsResponse.scala
@@ -152,12 +152,6 @@ object NiContributionsAndCreditsSuccess {
 
   }
 
-  case class TaxYear(value: Int) extends AnyVal
-
-  object TaxYear {
-    implicit val weeksPaidReads: Format[TaxYear] = Json.valueFormat[TaxYear]
-  }
-
   case class NumberOfCreditsAndContributions(value: Int) extends AnyVal
 
   object NumberOfCreditsAndContributions {

--- a/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/AggregatedDataBsp.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/AggregatedDataBsp.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.app.benefitEligibility.service.aggregation
 
 import uk.gov.hmrc.app.benefitEligibility.common.BenefitType.BSP
-import uk.gov.hmrc.app.benefitEligibility.common.{BenefitType, Identifier}
+import uk.gov.hmrc.app.benefitEligibility.common.{BenefitType, Identifier, TaxYear}
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.marriageDetails.model.response.MarriageDetailsSuccess.{
   MarriageEndDate,
   MarriageStartDate,

--- a/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/AggregatedDataGysp.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/AggregatedDataGysp.scala
@@ -78,7 +78,12 @@ case class SchemeMembershipDetailsDataGysp(
     employersContractedOutNumberDetails: String
 )
 
+case class BenefitSchemeName(
+    schemeName: String
+)
+
 case class AggregatedDataGysp(
+    benefitSchemeName: Option[BenefitSchemeName],
     totalGraduatedPensionUnits: Option[BigDecimal],
     class1CreditsAnsContributions: List[Class1CreditsAnsContributionsDataGysp],
     class2CreditsAnsContributions: List[Class2CreditsAnsContributionsGysp],

--- a/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/AggregatedDataMa.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/AggregatedDataMa.scala
@@ -17,19 +17,12 @@
 package uk.gov.hmrc.app.benefitEligibility.service.aggregation
 
 import uk.gov.hmrc.app.benefitEligibility.common.BenefitType.MA
-import uk.gov.hmrc.app.benefitEligibility.common.{BenefitType, ReceiptDate}
+import uk.gov.hmrc.app.benefitEligibility.common.{BenefitType, ReceiptDate, TaxYear}
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.niContributionsAndCredits.model.response.NiContributionsAndCreditsSuccess.{
-  ContributionCategoryLetter,
-  EmployerName,
-  NiClass1,
-  NiClass2,
-  NiContributionsAndCreditsSuccessResponse,
   NumberOfCreditsAndContributions,
-  PrimaryPaidEarnings,
-  TaxYear
+  PrimaryPaidEarnings
 }
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.niContributionsAndCredits.model.response.enums.{
-  ContributionCategory,
   ContributionCreditType,
   LatePaymentPeriod
 }

--- a/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/aggregators/AggregationServiceGysp.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/service/aggregation/aggregators/AggregationServiceGysp.scala
@@ -32,6 +32,7 @@ object AggregationServiceGysp {
         Right(
           AggregatedDataGysp(
             None,
+            None,
             List(),
             List(),
             List(),

--- a/app/uk/gov/hmrc/app/benefitEligibility/util/validation/MoneyValidation.scala
+++ b/app/uk/gov/hmrc/app/benefitEligibility/util/validation/MoneyValidation.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.app.benefitEligibility.util.SuccessfulResult.SuccessfulResult
 
 object MoneyValidation {
 
-  private object Defaults {
+  object Defaults {
 
     val max: BigDecimal = BigDecimal("99999999999999.98")
 

--- a/resources/public/api/conf/1.0/benefitEligibilityInfo_proposedSchema.yaml
+++ b/resources/public/api/conf/1.0/benefitEligibilityInfo_proposedSchema.yaml
@@ -664,6 +664,8 @@ components:
     GYSPResponseData:
       type: object
       properties:
+        benefitSchemeName:
+          $ref: '#/components/schemas/benefitSchemeName'
         totalGraduatedPensionUnits:
           $ref: '#/components/schemas/unsignedMoney'
         class1CreditsAndContributions:
@@ -1055,6 +1057,14 @@ components:
       minLength: 1
       maxLength: 6
       pattern: "^([A-Za-z ])+$"
+      type: string
+
+    benefitSchemeName:
+      description: The name of the scheme used for the institution details of
+        a benefit scheme.
+      maxLength: 54
+      minLength: 1
+      pattern: "^[a-zA-Z0-9\\/,'.&() -]+$"
       type: string
 
     # Enum Definitions

--- a/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/IndividualStatePensionInformationResponseSpec.scala
+++ b/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/individualStatePensionInformation/model/response/IndividualStatePensionInformationResponseSpec.scala
@@ -1,0 +1,621 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response
+
+import cats.data.Validated.Valid
+import cats.data.{NonEmptyList, Validated}
+import com.networknt.schema.SpecVersion
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{Format, JsValue, Json}
+import uk.gov.hmrc.app.benefitEligibility.common.*
+import uk.gov.hmrc.app.benefitEligibility.common.BenefitType.MA
+import uk.gov.hmrc.app.benefitEligibility.common.NpsErrorCode400.{NpsErrorCode400_1, NpsErrorCode400_2}
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.IndividualStatePensionInformationError.*
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.IndividualStatePensionInformationSuccess.*
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.enums.{
+  ContributionCreditType,
+  CreditSourceType
+}
+import uk.gov.hmrc.app.benefitEligibility.testUtils.SchemaValidation.SimpleJsonSchema
+import uk.gov.hmrc.app.benefitEligibility.testUtils.TestFormat.IndividualStatePensionInformation.*
+
+class IndividualStatePensionInformationResponseSpec extends AnyFreeSpec with Matchers {
+
+  val individualStatePensionInformationOpenApiSpec =
+    "test/resources/schemas/api/individualStatePensionInformation/individualStatePensionInformation.yaml"
+
+  "IndividualStatePensionInformationResponse" - {
+
+    "IndividualStatePensionInformationSuccessResponse" - {
+
+      def individualStatePensionInformationSuccessResponseJsonSchema: SimpleJsonSchema =
+        SimpleJsonSchema(
+          individualStatePensionInformationOpenApiSpec,
+          SpecVersion.VersionFlag.V7,
+          Some("GetNIRecordResponse"),
+          metaSchemaValidation = Some(Valid(()))
+        )
+
+      val jsonFormat = implicitly[Format[IndividualStatePensionInformationSuccessResponse]]
+
+      val individualStatePensionInformationSuccessResponse = IndividualStatePensionInformationSuccessResponse(
+        identifier = Identifier("AA000001A"),
+        numberOfQualifyingYears = Some(NumberOfQualifyingYears(35)),
+        nonQualifyingYears = Some(NonQualifyingYears(5)),
+        yearsToFinalRelevantYear = Some(YearsToFinalRelevantYear(3)),
+        nonQualifyingYearsPayable = Some(NonQualifyingYearsPayable(2)),
+        pre1975CCCount = Some(Pre1975CCCount(156)),
+        dateOfEntry = Some(DateOfEntry("1975-04-06")),
+        contributionsByTaxYear = Some(
+          List(
+            ContributionsByTaxYear(
+              taxYear = Some(TaxYear(2022)),
+              qualifyingTaxYear = Some(QualifyingTaxYear(true)),
+              payableAccepted = Some(PayableAccepted(false)),
+              amountNeeded = Some(AmountNeeded(BigDecimal("1250.50"))),
+              classThreePayable = Some(ClassThreePayable(BigDecimal("824.20"))),
+              classThreePayableBy = Some(ClassThreePayableBy("2028-04-05")),
+              classThreePayableByPenalty = Some(ClassThreePayableByPenalty("2030-04-05")),
+              classTwoPayable = Some(ClassTwoPayable(BigDecimal("164.25"))),
+              classTwoPayableBy = Some(ClassTwoPayableBy("2028-01-31")),
+              classTwoPayableByPenalty = Some(ClassTwoPayableByPenalty("2030-01-31")),
+              classTwoOutstandingWeeks = Some(ClassTwoOutstandingWeeks(12)),
+              totalPrimaryContributions = Some(TotalPrimaryContributions(BigDecimal("3456.78"))),
+              niEarnings = Some(NiEarnings(BigDecimal("45000.00"))),
+              coClassOnePaid = Some(CoClassOnePaid(BigDecimal("1234.56"))),
+              totalPrimaryEarnings = Some(TotalPrimaryEarnings(BigDecimal("52000.00"))),
+              niEarningsSelfEmployed = Some(NiEarningsSelfEmployed(25)),
+              niEarningsVoluntary = Some(NiEarningsVoluntary(8)),
+              underInvestigationFlag = Some(UnderInvestigationFlag(true)),
+              primaryPaidEarnings = Some(PrimaryPaidEarnings(BigDecimal("48500.75"))),
+              otherCredits = Some(
+                List(
+                  OtherCredits(
+                    contributionCreditType = Some(ContributionCreditType.Class1Credit),
+                    creditSourceType = Some(CreditSourceType.JsaTapeInput),
+                    contributionCreditCount = Some(ContributionCreditCount(15))
+                  ),
+                  OtherCredits(
+                    contributionCreditType = Some(ContributionCreditType.Class3Credit),
+                    creditSourceType = Some(CreditSourceType.CarersCredit),
+                    contributionCreditCount = Some(ContributionCreditCount(52))
+                  ),
+                  OtherCredits(
+                    contributionCreditType = Some(ContributionCreditType.Class2NormalRate),
+                    creditSourceType = Some(CreditSourceType.ChildBenefit),
+                    contributionCreditCount = Some(ContributionCreditCount(-5))
+                  )
+                )
+              )
+            ),
+            ContributionsByTaxYear(
+              taxYear = Some(TaxYear(2023)),
+              qualifyingTaxYear = Some(QualifyingTaxYear(false)),
+              payableAccepted = Some(PayableAccepted(true)),
+              amountNeeded = Some(AmountNeeded(BigDecimal("2100.75"))),
+              classThreePayable = Some(ClassThreePayable(BigDecimal("876.80"))),
+              classThreePayableBy = Some(ClassThreePayableBy("2029-04-05")),
+              classThreePayableByPenalty = Some(ClassThreePayableByPenalty("2031-04-05")),
+              classTwoPayable = Some(ClassTwoPayable(BigDecimal("175.60"))),
+              classTwoPayableBy = Some(ClassTwoPayableBy("2029-01-31")),
+              classTwoPayableByPenalty = Some(ClassTwoPayableByPenalty("2031-01-31")),
+              classTwoOutstandingWeeks = Some(ClassTwoOutstandingWeeks(35)),
+              totalPrimaryContributions = Some(TotalPrimaryContributions(BigDecimal("2987.45"))),
+              niEarnings = Some(NiEarnings(BigDecimal("38500.25"))),
+              coClassOnePaid = Some(CoClassOnePaid(BigDecimal("987.65"))),
+              totalPrimaryEarnings = Some(TotalPrimaryEarnings(BigDecimal("41250.80"))),
+              niEarningsSelfEmployed = Some(NiEarningsSelfEmployed(42)),
+              niEarningsVoluntary = Some(NiEarningsVoluntary(15)),
+              underInvestigationFlag = Some(UnderInvestigationFlag(false)),
+              primaryPaidEarnings = Some(PrimaryPaidEarnings(BigDecimal("39875.90"))),
+              otherCredits = Some(
+                List(
+                  OtherCredits(
+                    contributionCreditType = Some(ContributionCreditType.Class1Credit),
+                    creditSourceType = Some(CreditSourceType.UniversalCredit),
+                    contributionCreditCount = Some(ContributionCreditCount(26))
+                  ),
+                  OtherCredits(
+                    contributionCreditType = Some(ContributionCreditType.Class2VoluntaryDevelopmentWorkerRateA),
+                    creditSourceType = Some(CreditSourceType.StatutoryMaternityPayCredit),
+                    contributionCreditCount = Some(ContributionCreditCount(12))
+                  ),
+                  OtherCredits(
+                    contributionCreditType = Some(ContributionCreditType.Class3RateC),
+                    creditSourceType = Some(CreditSourceType.ModSpouseCivilPartnersCredits),
+                    contributionCreditCount = Some(ContributionCreditCount(39))
+                  ),
+                  OtherCredits(
+                    contributionCreditType = Some(ContributionCreditType.Class1EmployeeOnly),
+                    creditSourceType = Some(CreditSourceType.SharedParentalPay),
+                    contributionCreditCount = Some(ContributionCreditCount(-3))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+
+      val jsonString =
+        """{
+          |  "identifier": "AA000001A",
+          |  "numberOfQualifyingYears": 35,
+          |  "nonQualifyingYears": 5,
+          |  "yearsToFinalRelevantYear": 3,
+          |  "nonQualifyingYearsPayable": 2,
+          |  "pre1975CCCount": 156,
+          |  "dateOfEntry": "1975-04-06",
+          |  "contributionsByTaxYear": [
+          |    {
+          |      "taxYear": 2022,
+          |      "qualifyingTaxYear": true,
+          |      "payableAccepted": false,
+          |      "amountNeeded": 1250.50,
+          |      "classThreePayable": 824.20,
+          |      "classThreePayableBy": "2028-04-05",
+          |      "classThreePayableByPenalty": "2030-04-05",
+          |      "classTwoPayable": 164.25,
+          |      "classTwoPayableBy": "2028-01-31",
+          |      "classTwoPayableByPenalty": "2030-01-31",
+          |      "classTwoOutstandingWeeks": 12,
+          |      "totalPrimaryContributions": 3456.78,
+          |      "niEarnings": 45000.00,
+          |      "coClassOnePaid": 1234.56,
+          |      "totalPrimaryEarnings": 52000.00,
+          |      "niEarningsSelfEmployed": 25,
+          |      "niEarningsVoluntary": 8,
+          |      "underInvestigationFlag": true,
+          |      "primaryPaidEarnings": 48500.75,
+          |      "otherCredits": [
+          |        {
+          |          "contributionCreditType": "CLASS 1 CREDIT",
+          |          "creditSourceType": "JSA TAPE INPUT",
+          |          "contributionCreditCount": 15
+          |        },
+          |        {
+          |          "contributionCreditType": "CLASS 3 CREDIT",
+          |          "creditSourceType": "CARER'S CREDIT",
+          |          "contributionCreditCount": 52
+          |        },
+          |        {
+          |          "contributionCreditType": "CLASS 2 - NORMAL RATE",
+          |          "creditSourceType": "CHILD BENEFIT",
+          |          "contributionCreditCount": -5
+          |        }
+          |      ]
+          |    },
+          |    {
+          |      "taxYear": 2023,
+          |      "qualifyingTaxYear": false,
+          |      "payableAccepted": true,
+          |      "amountNeeded": 2100.75,
+          |      "classThreePayable": 876.80,
+          |      "classThreePayableBy": "2029-04-05",
+          |      "classThreePayableByPenalty": "2031-04-05",
+          |      "classTwoPayable": 175.60,
+          |      "classTwoPayableBy": "2029-01-31",
+          |      "classTwoPayableByPenalty": "2031-01-31",
+          |      "classTwoOutstandingWeeks": 35,
+          |      "totalPrimaryContributions": 2987.45,
+          |      "niEarnings": 38500.25,
+          |      "coClassOnePaid": 987.65,
+          |      "totalPrimaryEarnings": 41250.80,
+          |      "niEarningsSelfEmployed": 42,
+          |      "niEarningsVoluntary": 15,
+          |      "underInvestigationFlag": false,
+          |      "primaryPaidEarnings": 39875.90,
+          |      "otherCredits": [
+          |        {
+          |          "contributionCreditType": "CLASS 1 CREDIT",
+          |          "creditSourceType": "UNIVERSAL CREDIT",
+          |          "contributionCreditCount": 26
+          |        },
+          |        {
+          |          "contributionCreditType": "CLASS 2 - VOLUNTARY DEVELOPMENT WORKER'S RATE A",
+          |          "creditSourceType": "STATUTORY MATERNITY PAY CREDIT",
+          |          "contributionCreditCount": 12
+          |        },
+          |        {
+          |          "contributionCreditType": "CLASS 3 - RATE C",
+          |          "creditSourceType": "MOD SPOUSE/CIVIL PARTNER'S CREDITS",
+          |          "contributionCreditCount": 39
+          |        },
+          |        {
+          |          "contributionCreditType": "CLASS 1- EMPLOYEE ONLY",
+          |          "creditSourceType": "SHARED PARENTAL PAY",
+          |          "contributionCreditCount": -3
+          |        }
+          |      ]
+          |    }
+          |  ]
+          |}
+          |""".stripMargin
+
+      "should match the openapi schema validation for the fields required for a given benefit Type (MA)" in {
+
+        val invalidResponse = IndividualStatePensionInformationSuccessResponse(
+          identifier = Identifier("AA000001A"),
+          numberOfQualifyingYears = Some(NumberOfQualifyingYears(350)),
+          nonQualifyingYears = Some(NonQualifyingYears(5)),
+          yearsToFinalRelevantYear = Some(YearsToFinalRelevantYear(3)),
+          nonQualifyingYearsPayable = Some(NonQualifyingYearsPayable(2)),
+          pre1975CCCount = Some(Pre1975CCCount(156)),
+          dateOfEntry = Some(DateOfEntry("1975-04-06")),
+          contributionsByTaxYear = Some(
+            List(
+              ContributionsByTaxYear(
+                taxYear = Some(TaxYear(2022)),
+                qualifyingTaxYear = Some(QualifyingTaxYear(true)),
+                payableAccepted = Some(PayableAccepted(false)),
+                amountNeeded = Some(AmountNeeded(BigDecimal("1250.50"))),
+                classThreePayable = Some(ClassThreePayable(BigDecimal("824.20"))),
+                classThreePayableBy = Some(ClassThreePayableBy("2028-04-05")),
+                classThreePayableByPenalty = Some(ClassThreePayableByPenalty("2030-04-05")),
+                classTwoPayable = Some(ClassTwoPayable(BigDecimal("164.25"))),
+                classTwoPayableBy = Some(ClassTwoPayableBy("2028-01-31")),
+                classTwoPayableByPenalty = Some(ClassTwoPayableByPenalty("2030-01-31")),
+                classTwoOutstandingWeeks = Some(ClassTwoOutstandingWeeks(12)),
+                totalPrimaryContributions = Some(TotalPrimaryContributions(BigDecimal("3456.78"))),
+                niEarnings = Some(NiEarnings(BigDecimal("45000.00"))),
+                coClassOnePaid = Some(CoClassOnePaid(BigDecimal("1234.56"))),
+                totalPrimaryEarnings = Some(TotalPrimaryEarnings(BigDecimal("52000.00"))),
+                niEarningsSelfEmployed = Some(NiEarningsSelfEmployed(25)),
+                niEarningsVoluntary = Some(NiEarningsVoluntary(8)),
+                underInvestigationFlag = Some(UnderInvestigationFlag(true)),
+                primaryPaidEarnings = Some(PrimaryPaidEarnings(BigDecimal("485009999999999.75"))),
+                otherCredits = Some(
+                  List(
+                    OtherCredits(
+                      contributionCreditType = Some(ContributionCreditType.Class1Credit),
+                      creditSourceType = Some(CreditSourceType.JsaTapeInput),
+                      contributionCreditCount = Some(ContributionCreditCount(15))
+                    ),
+                    OtherCredits(
+                      contributionCreditType = Some(ContributionCreditType.Class3Credit),
+                      creditSourceType = Some(CreditSourceType.CarersCredit),
+                      contributionCreditCount = Some(ContributionCreditCount(52))
+                    ),
+                    OtherCredits(
+                      contributionCreditType = Some(ContributionCreditType.Class2NormalRate),
+                      creditSourceType = Some(CreditSourceType.ChildBenefit),
+                      contributionCreditCount = Some(ContributionCreditCount(-5))
+                    )
+                  )
+                )
+              ),
+              ContributionsByTaxYear(
+                taxYear = Some(TaxYear(2023)),
+                qualifyingTaxYear = Some(QualifyingTaxYear(false)),
+                payableAccepted = Some(PayableAccepted(true)),
+                amountNeeded = Some(AmountNeeded(BigDecimal("2100.75"))),
+                classThreePayable = Some(ClassThreePayable(BigDecimal("876.80"))),
+                classThreePayableBy = Some(ClassThreePayableBy("2029-04-05")),
+                classThreePayableByPenalty = Some(ClassThreePayableByPenalty("2031-04-05")),
+                classTwoPayable = Some(ClassTwoPayable(BigDecimal("175.60"))),
+                classTwoPayableBy = Some(ClassTwoPayableBy("2029-01-31")),
+                classTwoPayableByPenalty = Some(ClassTwoPayableByPenalty("2031-01-31")),
+                classTwoOutstandingWeeks = Some(ClassTwoOutstandingWeeks(35)),
+                totalPrimaryContributions = Some(TotalPrimaryContributions(BigDecimal("2987.45"))),
+                niEarnings = Some(NiEarnings(BigDecimal("38500.25"))),
+                coClassOnePaid = Some(CoClassOnePaid(BigDecimal("987.65"))),
+                totalPrimaryEarnings = Some(TotalPrimaryEarnings(BigDecimal("41250.80"))),
+                niEarningsSelfEmployed = Some(NiEarningsSelfEmployed(42)),
+                niEarningsVoluntary = Some(NiEarningsVoluntary(15)),
+                underInvestigationFlag = Some(UnderInvestigationFlag(false)),
+                primaryPaidEarnings = Some(PrimaryPaidEarnings(BigDecimal("39875.90"))),
+                otherCredits = Some(
+                  List(
+                    OtherCredits(
+                      contributionCreditType = Some(ContributionCreditType.Class1Credit),
+                      creditSourceType = Some(CreditSourceType.UniversalCredit),
+                      contributionCreditCount = Some(ContributionCreditCount(26))
+                    ),
+                    OtherCredits(
+                      contributionCreditType = Some(ContributionCreditType.Class2VoluntaryDevelopmentWorkerRateA),
+                      creditSourceType = Some(CreditSourceType.StatutoryMaternityPayCredit),
+                      contributionCreditCount = Some(ContributionCreditCount(12))
+                    ),
+                    OtherCredits(
+                      contributionCreditType = Some(ContributionCreditType.Class3RateC),
+                      creditSourceType = Some(CreditSourceType.ModSpouseCivilPartnersCredits),
+                      contributionCreditCount = Some(ContributionCreditCount(39))
+                    ),
+                    OtherCredits(
+                      contributionCreditType = Some(ContributionCreditType.Class1EmployeeOnly),
+                      creditSourceType = Some(CreditSourceType.SharedParentalPay),
+                      contributionCreditCount = Some(ContributionCreditCount(-3))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+
+        IndividualStatePensionInformationResponseValidation.individualStatePensionInformationResponseValidator.validate(
+          MA,
+          invalidResponse
+        ) shouldBe Validated.Invalid(
+          NonEmptyList.of(
+            """NumberOfQualifyingYears value exceeds the maximum allowed limit of 100""",
+            """PrimaryPaidEarnings value exceeds the maximum allowed limit of 99999999999999.98"""
+          )
+        )
+
+        individualStatePensionInformationSuccessResponseJsonSchema.validateAndGetErrors(
+          Json.toJson(invalidResponse)
+        ) shouldBe
+          List(
+            """$.contributionsByTaxYear[0].primaryPaidEarnings: must have a maximum value of 9.999999999999998E13""",
+            """$.numberOfQualifyingYears: must have a maximum value of 100"""
+          )
+      }
+
+      "should match the openapi schema for a full response" in {
+        individualStatePensionInformationSuccessResponseJsonSchema.validateAndGetErrors(
+          Json.toJson(individualStatePensionInformationSuccessResponse)
+        ) shouldBe Nil
+
+      }
+
+      "deserialises and serialises successfully" in {
+        Json.toJson(individualStatePensionInformationSuccessResponse) shouldBe Json.parse(jsonString)
+      }
+
+      "deserialises to the model class" in {
+        val _: IndividualStatePensionInformationSuccessResponse = jsonFormat.reads(Json.parse(jsonString)).get
+      }
+
+      "deserialises and reserialises to the same thing (no JSON fields are ignored)" in {
+        val jValue: JsValue = Json.parse(jsonString)
+        val individualStatePensionInformationSuccessResponse: IndividualStatePensionInformationSuccessResponse =
+          jsonFormat.reads(jValue).get
+        val writtenJson: JsValue = jsonFormat.writes(individualStatePensionInformationSuccessResponse)
+
+        writtenJson shouldBe jValue
+      }
+
+    }
+    "HipFailureResponse400" - {
+
+      val jsonFormat = implicitly[Format[HipFailureResponse400]]
+
+      val hipFailureResponse400 = HipFailureResponse400(
+        origin = HipOrigin.Hip,
+        response = HipFailureResponse(failures =
+          List(
+            HipFailureItem(`type` = FailureType("blah_1"), reason = Reason("reason_1")),
+            HipFailureItem(`type` = FailureType("blah_2"), reason = Reason("reason_2")),
+            HipFailureItem(`type` = FailureType("blah_3"), reason = Reason("reason_3"))
+          )
+        )
+      )
+
+      val hipFailureResponse400JsonString =
+        """{
+          |  "origin": "HIP",
+          |  "response": {
+          |    "failures": [
+          |      {
+          |        "type": "blah_1",
+          |        "reason": "reason_1"
+          |      },
+          |      {
+          |        "type": "blah_2",
+          |        "reason": "reason_2"
+          |      },
+          |      {
+          |        "type": "blah_3",
+          |        "reason": "reason_3"
+          |      }
+          |    ]
+          |  }
+          |}""".stripMargin
+
+      "deserialises and serialises successfully" in {
+        Json.toJson(hipFailureResponse400) shouldBe Json.parse(
+          hipFailureResponse400JsonString
+        )
+      }
+
+      "deserialises to the model class" in {
+        val _: HipFailureResponse400 =
+          jsonFormat.reads(Json.parse(hipFailureResponse400JsonString)).get
+      }
+
+      "deserialises and reserialises to the same thing (no JSON fields are ignored)" in {
+        val jValue: JsValue = Json.parse(hipFailureResponse400JsonString)
+        val hipFailureResponse400: HipFailureResponse400 =
+          jsonFormat.reads(jValue).get
+        val writtenJson: JsValue = jsonFormat.writes(hipFailureResponse400)
+
+        writtenJson shouldBe jValue
+      }
+    }
+    "StandardErrorResponse400" - {
+
+      val jsonFormat = implicitly[Format[StandardErrorResponse400]]
+
+      val standardErrorResponse400 = StandardErrorResponse400(
+        origin = HipOrigin.Hip,
+        response = ErrorResponse400(
+          failures = List(
+            ErrorResourceObj400(reason = Reason("reason_1"), code = NpsErrorCode400_1),
+            ErrorResourceObj400(reason = Reason("reason_2"), code = NpsErrorCode400_2)
+          )
+        )
+      )
+
+      val standardErrorResponse400JsonString =
+        """{
+          |  "origin": "HIP",
+          |  "response": {
+          |    "failures": [
+          |      {
+          |        "reason": "reason_1",
+          |        "code": "400.1"
+          |      },
+          |      {
+          |        "reason": "reason_2",
+          |        "code": "400.2"
+          |      }
+          |    ]
+          |  }
+          |}""".stripMargin
+
+      "deserialises and serialises successfully" in {
+        Json.toJson(standardErrorResponse400) shouldBe Json.parse(
+          standardErrorResponse400JsonString
+        )
+      }
+
+      "deserialises to the model class" in {
+        val _: StandardErrorResponse400 =
+          jsonFormat.reads(Json.parse(standardErrorResponse400JsonString)).get
+      }
+
+      "deserialises and reserialises to the same thing (no JSON fields are ignored)" in {
+        val jValue: JsValue = Json.parse(standardErrorResponse400JsonString)
+        val standardErrorResponse400: StandardErrorResponse400 =
+          jsonFormat.reads(jValue).get
+        val writtenJson: JsValue = jsonFormat.writes(standardErrorResponse400)
+
+        writtenJson shouldBe jValue
+      }
+    }
+    "IndividualStatePensionInformationErrorResponse403" - {
+
+      val jsonFormat = implicitly[Format[IndividualStatePensionInformationErrorResponse403]]
+
+      val individualStatePensionInformationErrorResponse403_1 =
+        IndividualStatePensionInformationErrorResponse403(
+          NpsErrorReason403.UserUnauthorised,
+          NpsErrorCode403.NpsErrorCode403_1
+        )
+
+      val individualStatePensionInformationErrorResponse403_2 =
+        IndividualStatePensionInformationErrorResponse403(
+          NpsErrorReason403.Forbidden,
+          NpsErrorCode403.NpsErrorCode403_2
+        )
+
+      val individualStatePensionInformationErrorResponse403_1JsonString =
+        """{
+          |  "reason": "User Not Authorised",
+          |  "code": "403.1"
+          |}""".stripMargin
+
+      val individualStatePensionInformationErrorResponse403_2JsonString =
+        """{
+          |  "reason": "Forbidden",
+          |  "code": "403.2"
+          |}""".stripMargin
+
+      "deserialises and serialises successfully" in {
+        Json.toJson(individualStatePensionInformationErrorResponse403_1) shouldBe Json.parse(
+          individualStatePensionInformationErrorResponse403_1JsonString
+        )
+        Json.toJson(individualStatePensionInformationErrorResponse403_2) shouldBe Json.parse(
+          individualStatePensionInformationErrorResponse403_2JsonString
+        )
+      }
+
+      "deserialises to the model class" in {
+        val _: IndividualStatePensionInformationErrorResponse403 =
+          jsonFormat.reads(Json.parse(individualStatePensionInformationErrorResponse403_1JsonString)).get
+
+        val _: IndividualStatePensionInformationErrorResponse403 =
+          jsonFormat.reads(Json.parse(individualStatePensionInformationErrorResponse403_2JsonString)).get
+      }
+
+      "deserialises and reserialises to the same thing (no JSON fields are ignored)" in {
+        val jValue1: JsValue = Json.parse(individualStatePensionInformationErrorResponse403_1JsonString)
+        val individualStatePensionInformationErrorResponse403_1: IndividualStatePensionInformationErrorResponse403 =
+          jsonFormat.reads(jValue1).get
+        val writtenJson1: JsValue = jsonFormat.writes(individualStatePensionInformationErrorResponse403_1)
+
+        val jValue2: JsValue = Json.parse(individualStatePensionInformationErrorResponse403_2JsonString)
+        val individualStatePensionInformationErrorResponse403_2: IndividualStatePensionInformationErrorResponse403 =
+          jsonFormat.reads(jValue2).get
+        val writtenJson2: JsValue = jsonFormat.writes(individualStatePensionInformationErrorResponse403_2)
+
+        writtenJson1 shouldBe jValue1
+        writtenJson2 shouldBe jValue2
+      }
+    }
+
+    "IndividualStatePensionInformationErrorResponse503" - {
+
+      val jsonFormat = implicitly[Format[IndividualStatePensionInformationErrorResponse503]]
+
+      val individualStatePensionInformationErrorResponse503 = IndividualStatePensionInformationErrorResponse503(
+        origin = HipOrigin.Hip,
+        response = HipFailureResponse(failures =
+          List(
+            HipFailureItem(`type` = FailureType("blah_1"), reason = Reason("reason_1")),
+            HipFailureItem(`type` = FailureType("blah_2"), reason = Reason("reason_2")),
+            HipFailureItem(`type` = FailureType("blah_3"), reason = Reason("reason_3"))
+          )
+        )
+      )
+
+      val individualStatePensionInformationErrorResponse503JsonString =
+        """{
+          |  "origin": "HIP",
+          |  "response": {
+          |    "failures": [
+          |      {
+          |        "type": "blah_1",
+          |        "reason": "reason_1"
+          |      },
+          |      {
+          |        "type": "blah_2",
+          |        "reason": "reason_2"
+          |      },
+          |      {
+          |        "type": "blah_3",
+          |        "reason": "reason_3"
+          |      }
+          |    ]
+          |  }
+          |}""".stripMargin
+
+      "deserialises and serialises successfully" in {
+        Json.toJson(individualStatePensionInformationErrorResponse503) shouldBe Json.parse(
+          individualStatePensionInformationErrorResponse503JsonString
+        )
+      }
+
+      "deserialises to the model class" in {
+        val _: IndividualStatePensionInformationErrorResponse503 =
+          jsonFormat.reads(Json.parse(individualStatePensionInformationErrorResponse503JsonString)).get
+      }
+
+      "deserialises and reserialises to the same thing (no JSON fields are ignored)" in {
+        val jValue: JsValue = Json.parse(individualStatePensionInformationErrorResponse503JsonString)
+        val individualStatePensionInformationErrorResponse503: IndividualStatePensionInformationErrorResponse503 =
+          jsonFormat.reads(jValue).get
+        val writtenJson: JsValue = jsonFormat.writes(individualStatePensionInformationErrorResponse503)
+
+        writtenJson shouldBe jValue
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/niContributionsAndCredits/model/response/NiContributionsAndCreditsResponseSpec.scala
+++ b/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/niContributionsAndCredits/model/response/NiContributionsAndCreditsResponseSpec.scala
@@ -28,13 +28,14 @@ import uk.gov.hmrc.app.benefitEligibility.common.{
   NpsErrorCode400,
   NpsErrorCode403,
   NpsErrorReason403,
-  Reason
+  Reason,
+  TaxYear
 }
-import uk.gov.hmrc.app.benefitEligibility.integration.outbound.niContributionsAndCredits.model.response.NiContributionsAndCreditsError._
-import uk.gov.hmrc.app.benefitEligibility.integration.outbound.niContributionsAndCredits.model.response.NiContributionsAndCreditsSuccess._
-import uk.gov.hmrc.app.benefitEligibility.integration.outbound.niContributionsAndCredits.model.response.enums._
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.niContributionsAndCredits.model.response.NiContributionsAndCreditsError.*
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.niContributionsAndCredits.model.response.NiContributionsAndCreditsSuccess.*
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.niContributionsAndCredits.model.response.enums.*
 import uk.gov.hmrc.app.benefitEligibility.testUtils.SchemaValidation.SimpleJsonSchema
-import uk.gov.hmrc.app.benefitEligibility.testUtils.TestFormat.ContributionCreditFormats._
+import uk.gov.hmrc.app.benefitEligibility.testUtils.TestFormat.ContributionCreditFormats.*
 
 class NiContributionsAndCreditsResponseSpec extends AnyFreeSpec with Matchers {
 

--- a/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/schemeMembershipDetails/model/response/SchemeMembershipDetailsResponseSpec.scala
+++ b/test/uk/gov/hmrc/app/benefitEligibility/integration/outbound/schemeMembershipDetails/model/response/SchemeMembershipDetailsResponseSpec.scala
@@ -435,12 +435,14 @@ class SchemeMembershipDetailsResponseSpec extends AnyFreeSpec with Matchers {
 
       "deserialises and reserialises to the same thing (no JSON fields are ignored)" in {
         val jValue1: JsValue = Json.parse(schemeMembershipDetailsErrorResponse403_1JsonString)
-        val class2MAReceiptsErrorResponse403_1: SchemeMembershipDetailsErrorResponse403 = jsonFormat.reads(jValue1).get
-        val writtenJson1: JsValue = jsonFormat.writes(class2MAReceiptsErrorResponse403_1)
+        val schemeMembershipDetailsErrorResponse403_1: SchemeMembershipDetailsErrorResponse403 =
+          jsonFormat.reads(jValue1).get
+        val writtenJson1: JsValue = jsonFormat.writes(schemeMembershipDetailsErrorResponse403_1)
 
         val jValue2: JsValue = Json.parse(schemeMembershipDetailsErrorResponse403_2JsonString)
-        val class2MAReceiptsErrorResponse403_2: SchemeMembershipDetailsErrorResponse403 = jsonFormat.reads(jValue2).get
-        val writtenJson2: JsValue = jsonFormat.writes(class2MAReceiptsErrorResponse403_2)
+        val schemeMembershipDetailsErrorResponse403_2: SchemeMembershipDetailsErrorResponse403 =
+          jsonFormat.reads(jValue2).get
+        val writtenJson2: JsValue = jsonFormat.writes(schemeMembershipDetailsErrorResponse403_2)
 
         writtenJson1 shouldBe jValue1
         writtenJson2 shouldBe jValue2

--- a/test/uk/gov/hmrc/app/benefitEligibility/testUtils/TestFormat.scala
+++ b/test/uk/gov/hmrc/app/benefitEligibility/testUtils/TestFormat.scala
@@ -19,6 +19,12 @@ package uk.gov.hmrc.app.benefitEligibility.testUtils
 import play.api.libs.json.{Format, Json, Writes}
 import uk.gov.hmrc.app.benefitEligibility.common.ErrorCode422
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.class2MAReceipts.model.response.Class2MAReceiptsError.*
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.IndividualStatePensionInformationError
+import uk.gov.hmrc.app.benefitEligibility.integration.outbound.individualStatePensionInformation.model.response.IndividualStatePensionInformationError.{
+  HipFailureResponse400,
+  IndividualStatePensionInformationErrorResponse503,
+  StandardErrorResponse400
+}
 import uk.gov.hmrc.app.benefitEligibility.integration.outbound.liabilitySummaryDetails.model.response.LiabilitySummaryDetailsError.{
   LiabilitySummaryDetailsError400,
   LiabilitySummaryDetailsError422,
@@ -149,6 +155,26 @@ object TestFormat {
 
     implicit val schemeMembershipDetailsSuccessResponseWrites: Writes[SchemeMembershipDetailsSuccessResponse] =
       Json.writes[SchemeMembershipDetailsSuccessResponse]
+
+  }
+
+  object IndividualStatePensionInformation {
+
+    implicit val hipFailureResponse400Writes: Writes[HipFailureResponse400] =
+      Json.writes[HipFailureResponse400]
+
+    implicit val errorResourceObj400Writes: Writes[IndividualStatePensionInformationError.ErrorResourceObj400] =
+      Json.writes[IndividualStatePensionInformationError.ErrorResourceObj400]
+
+    implicit val errorResponse400Writes: Writes[IndividualStatePensionInformationError.ErrorResponse400] =
+      Json.writes[IndividualStatePensionInformationError.ErrorResponse400]
+
+    implicit val standardErrorResponse400Writes: Writes[StandardErrorResponse400] =
+      Json.writes[StandardErrorResponse400]
+
+    implicit val individualStatePensionInformationErrorResponse503Writes
+        : Writes[IndividualStatePensionInformationErrorResponse503] =
+      Json.writes[IndividualStatePensionInformationErrorResponse503]
 
   }
 


### PR DESCRIPTION
Adds model for the individual state pension API also adds missing field to GYSP response in schema and aggregation